### PR TITLE
OCTO-1502 removed variant_subset parameter...

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -404,7 +404,6 @@ class Experiment(ExperimentData):
 	def fixed_horizon_delta(self,
 							res,
 							kpis_to_analyse=None,
-					 		variant_subset=None,
 			  		 		assume_normal=True,
 			  		 		percentiles=[2.5, 97.5],
 			  		 		min_observations=20,
@@ -453,11 +452,6 @@ class Experiment(ExperimentData):
 	        Results object containing the computed deltas.
 	    """
 		kpis_to_analyse = kpis_to_analyse or self.kpi_names.copy()
-		treat_variants = self.variant_names - set([self.baseline_variant])
-		self.dbg(3, 'treat_variants before subset: ' + ','.join(treat_variants))
-		if variant_subset is not None:
-			treat_variants.intersection_update(variant_subset)
-		self.dbg(3, 'treat_variants to analyse: ' + ','.join(treat_variants))
 
 		for mname in kpis_to_analyse:
 			# the weighted approach implies that derived_kpis is not None

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -601,8 +601,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
 		Check if the unequal variance warning message is persisted to the Results structure
     	"""
 		res = mock_results_object(self.data, variant_subset=['A'])
-		result = self.data.fixed_horizon_delta(res, kpis_to_analyse=['normal_unequal_variance'],
-								 variant_subset=['A'])
+		result = self.data.fixed_horizon_delta(res, kpis_to_analyse=['normal_unequal_variance'])
 		w = result.metadata['warnings']['Experiment.delta']
 		self.assertTrue(isinstance(w, UserWarning))
 		self.assertTrue(w.args[0] == 'Sample variances differ too much to assume that population variances are equal.')


### PR DESCRIPTION
OCTO-1502

... from the args list of `Experiment.fixed_horizon_delta()`

In the current implementation of `Experiment.fixed_horizon_delta()`, the parameter `variant_subset` and all derivatives of it are ignored - hence, it's safe to remove it from the argument list.