### PR TITLE
OCTO-1677 : fix missing .stan files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include README.rst
 include requirements.txt
 
 recursive-include tests *
+recursive-include expan/models *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,5 @@ setup(
 		'Programming Language :: Python :: 3.5',
 	],
 	test_suite='tests',
-	tests_require=test_requirements,
-	package_data={'expan': ['models/*.stan']}
+	tests_require=test_requirements
 )


### PR DESCRIPTION
NB: package_data is relevant only for `setup.py bdist`