### PR TITLE
OCTO-1748: Make number of iterations as a method argument in _bayes_sampling

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -301,6 +301,7 @@ class Experiment(ExperimentData):
                            reference_kpis={},
                            weighted_kpis=None,
                            distribution='normal',
+                           num_iters=25000,
                            **kwargs):
         """
         Calculate the stopping criterion based on the Bayes factor 
@@ -311,6 +312,7 @@ class Experiment(ExperimentData):
             kpis_to_analyse: list of KPIs to be analysed
             distribution: name of the KPI distribution model, which assumes a
                 Stan model file with the same name exists
+            num_iters: number of iterations for the bayes sampling
 
         Returns:
             a Results object
@@ -325,7 +327,8 @@ class Experiment(ExperimentData):
                                                    *es.bayes_factor(
                                                        x=weighted_x,
                                                        y=weighted_y,
-                                                       distribution=distribution))
+                                                       distribution=distribution,
+                                                       num_iters=num_iters))
 
             df = metric_df.groupby('variant').apply(self._apply_reweighting_and_all_variants,
                                                     metric_df=metric_df,
@@ -351,6 +354,7 @@ class Experiment(ExperimentData):
                               weighted_kpis=None,
                               distribution='normal',
                               posterior_width=0.08,
+                              num_iters=25000,
                               **kwargs):
         """
         Calculate the stopping criterion based on the precision of the posterior 
@@ -363,6 +367,7 @@ class Experiment(ExperimentData):
                 Stan model file with the same name exists
             posterior_width: the stopping criterion, threshold of the posterior 
                 width
+            num_iters: number of iterations for the bayes sampling
 
         Returns:
             a Results object
@@ -378,7 +383,8 @@ class Experiment(ExperimentData):
                                                        x=weighted_x,
                                                        y=weighted_y,
                                                        distribution=distribution,
-                                                       posterior_width=posterior_width))
+                                                       posterior_width=posterior_width,
+                                                       num_iters=num_iters))
 
             df = metric_df.groupby('variant').apply(self._apply_reweighting_and_all_variants,
                                                     metric_df=metric_df,

--- a/tests/tests_core/test_early_stopping.py
+++ b/tests/tests_core/test_early_stopping.py
@@ -79,11 +79,11 @@ class BayesFactorTestCases(EarlyStoppingTestCase):
         """
         Check the Bayes factor function.
         """
-        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_factor(self.rand_s1, self.rand_s2)
+        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_factor(self.rand_s1, self.rand_s2, num_iters=2000)
         self.assertEqual(stop, 1)
         self.assertAlmostEqual(delta, -0.15887364780635896)
-        self.assertAlmostEqual(CI['lower'], -0.2488832923198368)
-        self.assertAlmostEqual(CI['upper'], -0.074066551390901375)
+        self.assertAlmostEqual(CI['lower'], -0.24773660198455019)
+        self.assertAlmostEqual(CI['upper'], -0.077371302138420556)
         self.assertEqual(n_x, 1000)
         self.assertEqual(n_y, 1000)
         self.assertAlmostEqual(mu_x, -0.045256707490195384)
@@ -94,11 +94,12 @@ class BayesFactorTestCases(EarlyStoppingTestCase):
         """
         Check the Bayes factor function for Poisson distributions.
         """
-        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_factor(self.rand_s3, self.rand_s4, distribution='poisson')
+        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_factor(self.rand_s3, self.rand_s4, distribution='poisson',
+                                                                num_iters=2000)
         self.assertEqual(stop, 1)
         self.assertAlmostEqual(delta, -1.9589999999999999)
-        self.assertAlmostEqual(CI['lower'], -2.0713332592866109)
-        self.assertAlmostEqual(CI['upper'], -1.8258221195574416)
+        self.assertAlmostEqual(CI['lower'], -2.0732831978555764)
+        self.assertAlmostEqual(CI['upper'], -1.8275916374491907)
         self.assertEqual(n_x, 1000)
         self.assertEqual(n_y, 1000)
         self.assertAlmostEqual(mu_x, 0.96599999999999997)
@@ -123,11 +124,11 @@ class BayesPrecisionTestCases(EarlyStoppingTestCase):
         """
         Check the bayes_precision function.
         """
-        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_precision(self.rand_s1, self.rand_s2)
+        stop, delta, CI, n_x, n_y, mu_x, mu_y = es.bayes_precision(self.rand_s1, self.rand_s2, num_iters=2000)
         self.assertEqual(stop, 0)
         self.assertAlmostEqual(delta, -0.15887364780635896)
-        self.assertAlmostEqual(CI['lower'], -0.2488832923198368)
-        self.assertAlmostEqual(CI['upper'], -0.074066551390901375)
+        self.assertAlmostEqual(CI['lower'], -0.24773660198455019)
+        self.assertAlmostEqual(CI['upper'], -0.077371302138420556)
         self.assertEqual(n_x, 1000)
         self.assertEqual(n_y, 1000)
         self.assertAlmostEqual(mu_x, -0.045256707490195384)

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -329,12 +329,10 @@ class ExperimentClassTestCases(ExperimentTestCase):
         df = result.statistic('delta', 'uplift', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, ('value', 'A')],
                                        np.array([0.033053]), decimal=5)
-
         # check stop
         df = result.statistic('delta', 'stop', 'normal_same')
         np.testing.assert_equal(df.loc[:, 'value'],
                                 np.array([[0, 0]]))
-
         # check samplesize
         df = result.statistic('delta', 'sample_size', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, 'value'],
@@ -375,7 +373,6 @@ class ExperimentClassTestCases(ExperimentTestCase):
         df = result.statistic('delta', 'stop', 'normal_same')
         np.testing.assert_equal(df.loc[:, 'value'],
                                 np.array([[1, 0]]))
-
         # check samplesize
         df = result.statistic('delta', 'sample_size', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, 'value'],

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -329,10 +329,12 @@ class ExperimentClassTestCases(ExperimentTestCase):
         df = result.statistic('delta', 'uplift', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, ('value', 'A')],
                                        np.array([0.033053]), decimal=5)
+
         # check stop
         df = result.statistic('delta', 'stop', 'normal_same')
         np.testing.assert_equal(df.loc[:, 'value'],
                                 np.array([[0, 0]]))
+
         # check samplesize
         df = result.statistic('delta', 'sample_size', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, 'value'],
@@ -363,7 +365,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertTrue(self.experiment.baseline_variant == 'B')
 
         res = Results(None, metadata=self.experiment.metadata)
-        result = self.experiment.bayes_factor_delta(result=res, kpis_to_analyse=['normal_same'])
+        result = self.experiment.bayes_factor_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000)
 
         # check uplift
         df = result.statistic('delta', 'uplift', 'normal_same')
@@ -373,6 +375,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         df = result.statistic('delta', 'stop', 'normal_same')
         np.testing.assert_equal(df.loc[:, 'value'],
                                 np.array([[1, 0]]))
+
         # check samplesize
         df = result.statistic('delta', 'sample_size', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, 'value'],
@@ -395,7 +398,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertTrue(self.experiment.baseline_variant == 'B')
 
         res = Results(None, metadata=self.experiment.metadata)
-        result = self.experiment.bayes_precision_delta(result=res, kpis_to_analyse=['normal_same'])
+        result = self.experiment.bayes_precision_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000)
 
         # check uplift
         df = result.statistic('delta', 'uplift', 'normal_same')
@@ -404,7 +407,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         # check stop
         df = result.statistic('delta', 'stop', 'normal_same')
         np.testing.assert_equal(df.loc[:, 'value'],
-                                np.array([[0, 0]]))
+                                np.array([[1, 0]]))
         # check samplesize
         df = result.statistic('delta', 'sample_size', 'normal_same')
         np.testing.assert_almost_equal(df.loc[:, 'value'],


### PR DESCRIPTION
Number of iterations for tests is decreased to 2000, tests assertions are adopted accordingly. 