### PR TITLE
OCTO-1619 Cleanup ExpAn code

### DIFF
--- a/expan/core/binning.py
+++ b/expan/core/binning.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 class Binning(object):
     def __init__(self):
-        """The Binning class has two subclasses: CategoricalBinning and NumericalBinning.
+        """
+        The Binning class has two subclasses: CategoricalBinning and NumericalBinning.
         """
         pass
 
@@ -46,7 +47,8 @@ class Binning(object):
 
 class CategoricalBinning(Binning):
     """
-    A CategoricalBinning is essentially a list of lists of categories. Each bin within a Binning is an ordered list of categories.
+    A CategoricalBinning is essentially a list of lists of categories. 
+    Each bin within a Binning is an ordered list of categories.
     """
 
     def __init__(self, data=None, nbins=None):
@@ -58,17 +60,15 @@ class CategoricalBinning(Binning):
         """
         super(CategoricalBinning, self).__init__()
         if data is None:
-            # NB: this will go through the property setters, so they will not be
-            # simply lists.
+            # NB: this will go through the property setters, so they will not be simply lists.
             self.categories = []
         else:
             self.categories = self._get_binning_categorical(data, nbins)
 
     def _get_binning_categorical(self, x, n_bins):
-        """Generates a dictionary of Interval objects for categorical variables,
+        """
+        Generates a dictionary of Interval objects for categorical variables,
         divides into the same number of bins as the number of unique categories.
-        If aggregation of categories is desired, _mapping2binning should rather
-        be used.
 
         Args:
             x (array_like): input array
@@ -77,8 +77,7 @@ class CategoricalBinning(Binning):
             interval_dict (dict): dictionary with the key-value pair {name : Interval}
 
         """
-        # group NAs into a single interval, the effective n_bins will be increased
-        # by 1
+        # group NAs into a single interval, the effective n_bins will be increased by 1
         if any([is_number_and_nan(xx) for xx in x]):
             rest_list = self._get_binning_categorical([xx for xx in x if not is_number_and_nan(xx)], n_bins)
             return rest_list + [[np.nan]]
@@ -136,7 +135,9 @@ class CategoricalBinning(Binning):
 
     @property
     def _mids(self):
-        "The middle category of every bin"
+        """
+        The middle category of every bin
+        """
         return np.array(
             [None if len(c) == 0 else c[len(c) // 2] for c in self.categories]
         )
@@ -182,7 +183,6 @@ class CategoricalBinning(Binning):
                 format_args['set_notation'] = '{unseen}'
 
             if it is not None:
-                'ii: ' + str(ii)
                 if not is_catchall:
                     format_args['iterator'] = next(it)
                 else:
@@ -212,7 +212,9 @@ class CategoricalBinning(Binning):
         Note:
             This is not the same as label (which applies the bins to data and returns the labels of the data).
         """
-        return self._labels(format_str)[0:-1]
+        # NB: the last item in self._labels is the universal set symbol
+        # TODO: do we really need the universal set symbol?
+        return self._labels(format_str)[: -1]
 
     def _apply(self, data):
         """
@@ -275,7 +277,6 @@ class CategoricalBinning(Binning):
         Returns:
             array-like: array of the bin label corresponding to each data point
         """
-        lbls = None
         if format_str is None:  # TODO: remove this special case?
             lbls = self.mid(data)
         else:
@@ -290,16 +291,20 @@ class NumericalBinning(Binning):
     The Binning class for numerical variables.
 
     Todo:
-        Think of a good way of exposing the _apply() method, because with the returned indices, can then get uppers/lowers/mids/labels (ie reformat) without doing the apply again.
-        Am experimenting with maintaining the lists with a single element tacked onto the end representing non-matching entries.
+        Think of a good way of exposing the _apply() method, because with the returned indices, 
+        it can then get uppers/lowers/mids/labels (ie reformat) without doing the apply again.
+        And experimenting with maintaining the lists with a single element tacked onto the end representing non-matching entries.
 
-        All access then are through properties which drop this end list, except when using the indices returned by _apply.
+        All access then are through properties which drop this end list, 
+        except when using the indices returned by _apply.
 
-        This means that the -1 indices just works, so using the indices to get labels, bounds, etc., is straightforward and fast because it is just integer-based array slicing.
+        This means that the -1 indices just works, so using the indices to get labels, bounds, etc., 
+        is straightforward and fast because it is just integer-based array slicing.
     """
     def __init__(self, data=None, nbins=None, uppers=None, lowers=None,
                  up_closed=None, lo_closed=None):
-        """NumericalBinning constructor.
+        """
+        NumericalBinning constructor.
 
         Args:
             data (array-like): array of datapoints to be binned
@@ -346,13 +351,11 @@ class NumericalBinning(Binning):
             # self.up_closed[-1]=True
 
     def _get_binning_numeric_recursive(self, x, n_bins, open_ends=False):
-        """get_binning for numeric variables. All Intervals are ClosedOpenInterval
-        except the last one containing the maximum, which is then a
-        ClosedClosedInterval.
         """
-        # group NAs into a single interval, the effective n_bins will be increased
-        # by 1
-        # set_trace()
+        get_binning for numeric variables. All Intervals are ClosedOpenInterval
+        except the last one containing the maximum, which is then a ClosedClosedInterval.
+        """
+        # group NAs into a single interval, the effective n_bins will be increased by 1
         if any(np.isnan(x)):
             na_lower = [np.nan]
             na_upper = [np.nan]
@@ -390,7 +393,8 @@ class NumericalBinning(Binning):
         return first_lower, first_upper, first_lo_closed, first_up_closed
 
     def _first_interval(self, x, n_bins):
-        """Gets the first interval based on the percentiles, either a
+        """
+        Gets the first interval based on the percentiles, either a
         ClosedClosedInterval containing the same value multiple times or a
         ClosedOpenInterval with a different lower and upper bound.
         """
@@ -555,7 +559,7 @@ class NumericalBinning(Binning):
         Note:
             This is not the same as label (which applies the bins to data and returns the labels of the data)
         """
-        return self._labels(format_str)[0:-1]
+        return self._labels(format_str)[0: -1]
 
     @property
     def _mids(self):
@@ -646,7 +650,8 @@ class NumericalBinning(Binning):
         return self._bound(data, 'mid')
 
     def label(self, data, format_str='{standard}'):
-        """Return the bin labels associated with each data point in the series,
+        """
+        Returns the bin labels associated with each data point in the series,
         essentially 'applying' the binning to data.
 
         Args:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -101,11 +101,15 @@ class Experiment(ExperimentData):
         logger.debug('kpis_to_analyse: ' + ','.join(kpis_to_analyse))
 
         defaultArgs = [res, kpis_to_analyse, reference_kpis, weighted_kpis]
-        deltaWorker = statx.make_delta(assume_normal, percentiles, min_observations,
-                                       nruns, relative)
+        deltaWorker = statx.make_delta(assume_normal, percentiles, min_observations, nruns, relative)
+
+        alpha = 0.05
+        if percentiles is not None and len(percentiles) == 2:
+            alpha = (percentiles[0] + 100 - percentiles[1]) / 100
+
         method_table = {
             'fixed_horizon': (self.fixed_horizon_delta, defaultArgs + [deltaWorker]),
-            'group_sequential': (self.group_sequential_delta, defaultArgs),
+            'group_sequential': (self.group_sequential_delta, defaultArgs + [alpha]),
             'bayes_factor': (self.bayes_factor_delta, defaultArgs),
             'bayes_precision': (self.bayes_precision_delta, defaultArgs),
         }
@@ -235,9 +239,9 @@ class Experiment(ExperimentData):
                                kpis_to_analyse,
                                reference_kpis={},
                                weighted_kpis=None,
+                               alpha=0.05,
                                spending_function='obrien_fleming',
                                information_fraction=1,
-                               alpha=0.05,
                                cap=8,
                                **kwargs):
         """

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -6,7 +6,7 @@ from scipy import stats
 
 
 def _delta_mean(x, y):
-    "Implemented as function to allow calling from bootstrap."
+    """Implemented as function to allow calling from bootstrap. """
     return np.nanmean(x) - np.nanmean(y)
 
 

--- a/expan/core/util.py
+++ b/expan/core/util.py
@@ -1,4 +1,4 @@
-import warnings
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -63,9 +63,8 @@ def scale_range(x, new_min=0.0, new_max=1.0, old_min=None, old_max=None, squash_
 
   """
     if squash_inf and not squash_outside_range:
-        # TODO: "warn" is an unresolved reference
-        warn(ValueError(
-            'Makes no sense to squash infinity but not other numbers outside the source range. Will squash all outside range.'))
+        warn(ValueError('Makes no sense to squash infinity but not other numbers outside the source range. \
+         Will squash all outside range.'))
         squash_outside_range = True
 
     if isinstance(x, list):
@@ -103,8 +102,9 @@ def generate_random_data():
     test_data_frame['normal_same'] = np.random.normal(size=size)
     test_data_frame['normal_shifted'] = np.random.normal(size=size)
 
+    size_shifted_B = test_data_frame['normal_shifted'][test_data_frame['variant'] == 'B'].shape[0]
     test_data_frame.loc[test_data_frame['variant'] == 'B', 'normal_shifted'] \
-        = np.random.normal(loc=1.0, size=test_data_frame['normal_shifted'][test_data_frame['variant'] == 'B'].shape[0])
+        = np.random.normal(loc=1.0, size=size_shifted_B)
 
     test_data_frame['feature'] = np.random.choice(['has', 'non'], size=size)
     test_data_frame['normal_shifted_by_feature'] = np.random.normal(size=size)
@@ -115,9 +115,10 @@ def generate_random_data():
 
     test_data_frame['treatment_start_time'] = np.random.choice(list(range(10)), size=size)
     test_data_frame['normal_unequal_variance'] = np.random.normal(size=size)
-    test_data_frame.loc[test_data_frame['variant'] == 'B', 'normal_unequal_variance'] \
-        = np.random.normal(scale=10,
-                           size=test_data_frame['normal_unequal_variance'][test_data_frame['variant'] == 'B'].shape[0])
+
+    size_unequalvar_B = test_data_frame['normal_unequal_variance'][test_data_frame['variant'] == 'B'].shape[0]
+    test_data_frame.loc[test_data_frame['variant'] == 'B','normal_unequal_variance'] \
+        = np.random.normal(scale=10, size=size_unequalvar_B)
 
     metadata = {
         'primary_KPI': 'normal_shifted',

--- a/expan/core/version.py
+++ b/expan/core/version.py
@@ -8,10 +8,10 @@ def version_numbers():
 
 def git_commit_count():
     """
-      Returns the output of `git rev-list --count HEAD` as an int.
+    Returns the output of `git rev-list --count HEAD` as an int.
 
-      Note:
-          http://programmers.stackexchange.com/a/151558
+    Note:
+        http://programmers.stackexchange.com/a/151558
     """
 
     return int(subprocess.check_output(["git", "rev-list", "--count", "HEAD"]))
@@ -19,7 +19,7 @@ def git_commit_count():
 
 def git_latest_commit():
     """"
-      Returns output of `git rev-parse HEAD`.
+    Returns output of `git rev-parse HEAD`.
 
     Note:
         http://programmers.stackexchange.com/a/151558


### PR DESCRIPTION
The only functional change is this PR is
* support calculating ```alpha``` of ```group_sequential_delta``` from the user-given ```pctile``` in ```delta```, rather than always setting a hard value ```alpha=0.05``` in the group sequential method. This allows ExpAn to be more flexible as a library.

The remaining are simply code cleanup.