### PR TITLE
Stan models compilation, exceptions catch, unit tests adaptation.

### DIFF
--- a/expan/core/early_stopping.py
+++ b/expan/core/early_stopping.py
@@ -128,8 +128,8 @@ def HDI_from_MCMC(posterior_samples, credible_mass=0.95):
 
 def compile_stan_model(model_file, distribution):
     """
-    Creates Stan model. Compiles a Stan model and saves it to .pkl file to the /tmp folder if
-        file doesn't exist yet and load precompiled model if there is a model file in the /tmp.
+    Creates Stan model. Compiles a Stan model and saves it to .pkl file to the folder selected by tempfile module if
+        file doesn't exist yet and load precompiled model if there is a model file in temporary dir.
     Args:
         model_file: model file location
         distribution: name of the KPI distribution model, which assumes a 

--- a/expan/core/early_stopping.py
+++ b/expan/core/early_stopping.py
@@ -126,7 +126,7 @@ def HDI_from_MCMC(posterior_samples, credible_mass=0.95):
     return (HDImin, HDImax)
 
 
-def compile_stan_model(model_file, distribution):
+def get_or_compile_stan_model(model_file, distribution):
     """
     Creates Stan model. Compiles a Stan model and saves it to .pkl file to the folder selected by tempfile module if
         file doesn't exist yet and load precompiled model if there is a model file in temporary dir.
@@ -206,7 +206,7 @@ def _bayes_sampling(x, y, distribution='normal', num_iters=25000):
 
     model_file = __location__ + '/../models/' + distribution + '_kpi.stan'
 
-    sm = compile_stan_model(model_file, distribution)
+    sm = get_or_compile_stan_model(model_file, distribution)
 
     fit = sm.sampling(data=fit_data, iter=num_iters, chains=4, n_jobs=1, seed=1,
                       control={'stepsize': 0.01, 'adapt_delta': 0.99})

--- a/expan/core/util.py
+++ b/expan/core/util.py
@@ -2,9 +2,6 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-import os
-
-from os.path import dirname, join, realpath
 
 
 def is_number_and_nan(obj):
@@ -154,14 +151,3 @@ def generate_random_data_n_variants(n_variants=3):
     }
 
     return test_data_frame, metadata
-
-
-def remove_model_pkls():
-    """
-    Removes .pkl compiled model files from the models folder.
-    """
-    __location__ = realpath(join(os.getcwd(), dirname(__file__)))
-    models_dir = __location__ + '/../../expan/models/'
-    for f in os.listdir(models_dir):
-        if f.endswith(".pkl"):
-            os.remove(join(models_dir, f))

--- a/tests/tests_core/test_early_stopping.py
+++ b/tests/tests_core/test_early_stopping.py
@@ -110,7 +110,7 @@ class BayesFactorTestCases(EarlyStoppingTestCase):
         """
         Check the Bayes factor function with input that contains nan values.
         """
-        stop, _, _, _, _, _, _ = es.bayes_factor(self.rand_s5, self.rand_s6)
+        stop, _, _, _, _, _, _ = es.bayes_factor(self.rand_s5, self.rand_s6, num_iters=2000)
         self.assertEqual(stop, 1)
 
 

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -5,17 +5,8 @@ import pandas as pd
 
 from expan.core.experiment import Experiment
 from expan.core.results import Results
-from expan.core.util import generate_random_data, remove_model_pkls
+from expan.core.util import generate_random_data
 from tests.tests_core.test_results import mock_results_object
-
-
-def tearDownModule():
-    """
-    Removes .pkl compiled model files from the models folder.
-    tearDownModule() is executed once after all tests of a particular module (test_experiment.py) are finished.
-    Bayes_precision_delta and bayes_factor_delta methods in experiment.py use the compiled models.
-    """
-    remove_model_pkls()
 
 
 class ExperimentTestCase(unittest.TestCase):
@@ -372,8 +363,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertTrue(self.experiment.baseline_variant == 'B')
 
         res = Results(None, metadata=self.experiment.metadata)
-        result = self.experiment.bayes_factor_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000,
-                                                    remove_pkls=False)
+        result = self.experiment.bayes_factor_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000)
 
         # check uplift
         df = result.statistic('delta', 'uplift', 'normal_same')
@@ -405,8 +395,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertTrue(self.experiment.baseline_variant == 'B')
 
         res = Results(None, metadata=self.experiment.metadata)
-        result = self.experiment.bayes_precision_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000,
-                                                       remove_pkls=False)
+        result = self.experiment.bayes_precision_delta(result=res, kpis_to_analyse=['normal_same'], num_iters=2000)
 
         # check uplift
         df = result.statistic('delta', 'uplift', 'normal_same')

--- a/tests/tests_core/test_results.py
+++ b/tests/tests_core/test_results.py
@@ -163,7 +163,7 @@ class ResultsClassTestCase(ResultsTestCase):
         os.remove("test_json.json")
 
     def test_to_json_group_sequential(self):
-        json_object = json.loads(
+        json.loads(
             self.data.delta(method='group_sequential',
                 kpi_subset=['normal_same'],
                 percentiles=[2.5, 97.5]
@@ -172,19 +172,21 @@ class ResultsClassTestCase(ResultsTestCase):
 
     # @unittest.skip("sometimes takes too much time")
     def test_to_json_bayes_factor(self):
-        json_object = json.loads(
-            self.data.delta(method='bayes_factor',
-                kpi_subset=['normal_same'],
-                percentiles=[2.5, 97.5]
+        json.loads(
+            self.data.bayes_factor_delta(
+                result=results.Results(None, metadata=self.data.metadata),
+                kpis_to_analyse=['normal_same'],
+                num_iters=2000
             ).to_json()
         )
 
     # @unittest.skip("sometimes takes too much time")
     def test_to_json_bayes_precision(self):
-        json_object = json.loads(
-            self.data.delta(method='bayes_precision',
-                kpi_subset=['normal_same'],
-                percentiles=[2.5, 97.5]
+        json.loads(
+            self.data.bayes_precision_delta(
+                result=results.Results(None, metadata=self.data.metadata),
+                kpis_to_analyse=['normal_same'],
+                num_iters=2000
             ).to_json()
         )
 


### PR DESCRIPTION
1. Re-implemented Stan model load procedure: .pkl files (Stan models are pickable) with the compiled models are saved in the temporary folder defined by tempfile.gettempdir() which depends on the platform/os and settings.
2. Added check/exception if kpi_subset is not a list of strings.
3. Changed bayes-specific unit tests (to_json() tests) in order to pass fewer number of iterations.