### PR TITLE
Small improvement on default type of report_kpi_names

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -37,6 +37,9 @@ class Experiment(object):
         if type(report_kpi_names) is str:
             report_kpi_names = [report_kpi_names]
 
+        if type(report_kpi_names) is not list:
+            raise TypeError('report_kpi_names should be a list of str')
+
         if report_kpi_names:
             report_kpi_names_needed = set(report_kpi_names)
         else:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -30,20 +30,20 @@ class Experiment(object):
     """
     Class which adds the analysis functions to experimental data.
     """
-    def __init__(self, control_variant_name, data, metadata, report_kpi_names=None, derived_kpis=[]):
+    def __init__(self, control_variant_name, data, metadata, report_kpi_names=[], derived_kpis=[]):
         experiment_column_names = set(['entity', 'variant'])
         numerical_column_names  = set(get_column_names_by_type(data, np.number))
 
         if report_kpi_names:
-            report_kpi_names = set(report_kpi_names)
+            report_kpi_names_needed = set(report_kpi_names)
         else:
-            report_kpi_names = numerical_column_names - experiment_column_names
+            report_kpi_names_needed = numerical_column_names - experiment_column_names
 
         derived_kpi_names    = [k['name']    for k in derived_kpis]
         derived_kpi_formulas = [k['formula'] for k in derived_kpis]
 
         # what columns do we expect to find in the data frame?
-        required_column_names = (report_kpi_names | experiment_column_names) - set(derived_kpi_names)
+        required_column_names = (report_kpi_names_needed | experiment_column_names) - set(derived_kpi_names)
         kpi_name_pattern = '([a-zA-Z][0-9a-zA-Z_]*)'
         # add names from all formulas
         for formula in derived_kpi_formulas:
@@ -56,7 +56,7 @@ class Experiment(object):
 
         self.data                 =     data.copy()
         self.metadata             = metadata.copy()
-        self.report_kpi_names     = report_kpi_names
+        self.report_kpi_names     = report_kpi_names_needed
         self.derived_kpis         = derived_kpis
         self.variant_names        = set(self.data.variant)
         self.control_variant_name = control_variant_name

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -30,20 +30,23 @@ class Experiment(object):
     """
     Class which adds the analysis functions to experimental data.
     """
-    def __init__(self, control_variant_name, data, metadata, report_kpi_names=None, derived_kpis=[]):
+    def __init__(self, control_variant_name, data, metadata, report_kpi_names=[], derived_kpis=[]):
         experiment_column_names = set(['entity', 'variant'])
         numerical_column_names  = set(get_column_names_by_type(data, np.number))
 
+        if type(report_kpi_names) is str:
+            report_kpi_names = [report_kpi_names]
+
         if report_kpi_names:
-            report_kpi_names = set(report_kpi_names)
+            report_kpi_names_needed = set(report_kpi_names)
         else:
-            report_kpi_names = numerical_column_names - experiment_column_names
+            report_kpi_names_needed = numerical_column_names - experiment_column_names
 
         derived_kpi_names    = [k['name']    for k in derived_kpis]
         derived_kpi_formulas = [k['formula'] for k in derived_kpis]
 
         # what columns do we expect to find in the data frame?
-        required_column_names = (report_kpi_names | experiment_column_names) - set(derived_kpi_names)
+        required_column_names = (report_kpi_names_needed | experiment_column_names) - set(derived_kpi_names)
         kpi_name_pattern = '([a-zA-Z][0-9a-zA-Z_]*)'
         # add names from all formulas
         for formula in derived_kpi_formulas:
@@ -56,7 +59,7 @@ class Experiment(object):
 
         self.data                 =     data.copy()
         self.metadata             = metadata.copy()
-        self.report_kpi_names     = report_kpi_names
+        self.report_kpi_names     = report_kpi_names_needed
         self.derived_kpis         = derived_kpis
         self.variant_names        = set(self.data.variant)
         self.control_variant_name = control_variant_name

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -57,7 +57,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertEqual(round(a, decimals), round(b, decimals))
 
 
-    def getExperiment(self, report_kpi_names=None, derived_kpis=[]):
+    def getExperiment(self, report_kpi_names=[], derived_kpis=[]):
         return Experiment('B', self.data, self.metadata, report_kpi_names, derived_kpis)
 
 
@@ -65,7 +65,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.getExperiment()
 
         with self.assertRaises(ValueError):
-            experiment = self.getExperiment(self.column_names + ['non_existing'])
+            self.getExperiment(self.column_names + ['non_existing'])
 
         self.getExperiment(self.column_names + [self.derived_kpi_1['name'],
                                                 self.derived_kpi_2['name']],
@@ -81,6 +81,14 @@ class ExperimentClassTestCases(ExperimentTestCase):
             self.getExperiment(self.column_names + [self.derived_kpi_4['name'],
                                                     self.derived_kpi_2['name']],
                                [self.derived_kpi_4, self.derived_kpi_2])
+
+        with self.assertRaises(TypeError):
+            self.getExperiment(123)
+
+        self.getExperiment(['normal_same'])
+
+        # implicit do the conversion if there is one str
+        self.getExperiment('normal_same')
 
 
     def test_errors_warnings_expan_version(self):


### PR DESCRIPTION
To make it explicit that input argument should be a list because

```report_kpi_names='kpi'``` will lead to ```set(report_kpi_names)==set('k', 'p', 'i)```.