### PR TITLE
Octo 1930 implement quantile filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ deploy:
 env:
 - TOXENV=py
 install:
-- pip install -U pip setuptools tox coveralls
+#- pip install --upgrade pip setuptools tox coveralls
+- pip install tox coveralls
 - pip install -r requirements.txt
 language: python
 python:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -145,16 +145,21 @@ class Experiment(object):
         result['kpis'] = kpis
         return result
 
-    def _quantile_filtering(self, kpis, percentile):
+    def _quantile_filtering(self, kpis, percentile, kind):
         flags = pd.Series(data=[False]*len(self.data))
         for column in self.data[kpis].columns:
             threshold = np.percentile(self.data[column], percentile)
-            flags = flags | self.data[column].apply(
-                lambda x: x >= threshold,
-            )
+            if kind == 'upper':
+                flags = flags | self.data[column].apply(
+                    lambda x: x >= threshold,
+                )
+            elif kind == 'lower':
+                flags = flags | self.data[column].apply(
+                    lambda x: x <= threshold,
+                )
         return flags
 
-    def filter(self, kpis, percentile=99.0):
+    def filter(self, kpis, percentile=99.0, kind='upper'):
         """
         Method that filters out entities whose KPIs exceed the value at a given percentile.
         If any of the KPIs exceeds its threshold the entity is filtered out.
@@ -170,21 +175,26 @@ class Experiment(object):
         # check if provided KPIs are present in the data
         for kpi in kpis:
             if kpi not in self.data.columns:
-                raise KeyError(kpi + ' identifier not present in dataframe columns.')
+                raise KeyError(kpi + ' identifier not present in dataframe columns!')
 
         # check if provided percentile is valid
         if 0.0 < percentile <= 100.0 is False:
             raise ValueError("Percentile value needs to be between 0.0 and 100.0!")
 
+        # check if provided filtering kind is valid
+        if kind not in ['upper', 'lower']:
+            raise ValueError("Kind needs to be either 'upper' or 'lower'!")
+
         # run quantile filtering
-        flags = self._quantile_filtering(kpis=kpis, percentile=percentile)
+        flags = self._quantile_filtering(kpis=kpis, percentile=percentile, kind=kind)
 
         # log which columns were filtered and how many entities were filtered out
         self.metadata['filtered_columns'] = kpis
         self.metadata['filtered_entities_number'] = len(flags[flags == True])
+        self.metadata['filtered_threshold_kind'] = kind
 
         # throw warning if too many entities have been filtered out
-        if (len(flags[flags == True]) / len(self.data)) > 0.02:
+        if (len(flags[flags == True]) / float(len(self.data))) > 0.02:
             warnings.warn('More than 2% of entities have been filtered out, consider adjusting the percentile value.')
 
         self.data = self.data[flags == False]

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -150,21 +150,53 @@ class Experiment(object):
             return True
 
     def _quantile_filtering(self, df, percentile):
-        flags = pd.Series()
+        flags = None
         for column in df.columns:
-            flags = flags | df[column].apply(
-                self._quant_apply,
-                threshold=np.percentile(df[column], percentile)
+            if flags is None:
+                flags = df[column].apply(
+                    self._quant_apply,
+                    threshold=np.percentile(df[column], percentile)
             )
+            else:
+                flags = flags | df[column].apply(
+                    self._quant_apply,
+                    threshold=np.percentile(df[column], percentile)
+                )
         return flags
 
     def filter(self, kpis, percentile=99.0):
+        """
+        Method that filters out entities whose KPIs exceed the value at a given percentile.
+        If any of the KPIs exceeds its threshold the entity is filtered out.
+
+        Args:
+            kpis (list): list of KPI names
+            percentile (float): percentile considered as threshold
+
+        Returns:
+
+        """
+
+        # check if provided KPIs are present in the data
         for kpi in kpis:
             if kpi not in self.data.columns:
-                raise KeyError('kpi not in dataframe')
+                raise KeyError(kpi + ' identifier not present in dataframe columns.')
+
+        # check if provided percentile is valid
+        if 0.0 < percentile <= 100.0 is False:
+            raise ValueError("Percentile value needs to be between 0.0 and 100.0!")
 
         flags = self._quantile_filtering(df=self.data[kpis], percentile=percentile)
+
+        # log which columns were filtered and how many entities were filtered out
         metadata = {
-            # how the filtering should be logged
+            'filtered_columns': kpis,
+            'filtered_entities_number': len(flags[flags == True])
         }
-        return self.data[flags == False], metadata
+
+        # throw warning if too many entities have been filtered out
+        if (len(flags[flags == True]) / len(self.data)) > 0.02:
+            warnings.warn('More than 2% of entities have been filtered out, consider adjusting the percentile value.')
+
+        self.metadata = metadata
+        self.data = self.data[flags == False]

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -144,3 +144,30 @@ class Experiment(object):
 
         result['kpis'] = kpis
         return result
+
+    @staticmethod
+    def _quant_apply(value, threshold):
+        if value < threshold:
+            return False
+        else:
+            return True
+
+    def _quantile_filtering(self, df, percentile):
+        flags = pd.Series()
+        for column in df.columns:
+            flags = flags | df[column].apply(
+                self._quant_apply,
+                threshold=np.percentile(df[column], percentile)
+            )
+        return flags
+
+    def filter(self, kpis, percentile=99.0):
+        for kpi in kpis:
+            if kpi not in self.data.columns:
+                raise KeyError('kpi not in dataframe')
+
+        flags = self._quantile_filtering(df=self.data[kpis], percentile=percentile)
+        metadata = {
+            # how the filtering should be logged
+        }
+        return self.data[flags == False], metadata

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -145,21 +145,15 @@ class Experiment(object):
         result['kpis'] = kpis
         return result
 
-    def _quantile_filtering(self, kpis, percentile, kind):
+    def _quantile_filtering(self, kpis, percentile, threshold_type):
+        method_table = {'upper': lambda x: x > threshold, 'lower': lambda x: x <= threshold}
         flags = pd.Series(data=[False]*len(self.data))
         for column in self.data[kpis].columns:
             threshold = np.percentile(self.data[column], percentile)
-            if kind == 'upper':
-                flags = flags | self.data[column].apply(
-                    lambda x: x >= threshold,
-                )
-            elif kind == 'lower':
-                flags = flags | self.data[column].apply(
-                    lambda x: x <= threshold,
-                )
+            flags = flags | self.data[column].apply(method_table[threshold_type])
         return flags
 
-    def filter(self, kpis, percentile=99.0, kind='upper'):
+    def filter(self, kpis, percentile=99.0, threshold_type='upper'):
         """
         Method that filters out entities whose KPIs exceed the value at a given percentile.
         If any of the KPIs exceeds its threshold the entity is filtered out.
@@ -167,6 +161,7 @@ class Experiment(object):
         Args:
             kpis (list): list of KPI names
             percentile (float): percentile considered as threshold
+            threshold_type (string): type of threshold used ('lower' or 'upper')
 
         Returns:
 
@@ -182,16 +177,16 @@ class Experiment(object):
             raise ValueError("Percentile value needs to be between 0.0 and 100.0!")
 
         # check if provided filtering kind is valid
-        if kind not in ['upper', 'lower']:
-            raise ValueError("Kind needs to be either 'upper' or 'lower'!")
+        if threshold_type not in ['upper', 'lower']:
+            raise ValueError("Threshold type needs to be either 'upper' or 'lower'!")
 
         # run quantile filtering
-        flags = self._quantile_filtering(kpis=kpis, percentile=percentile, kind=kind)
+        flags = self._quantile_filtering(kpis=kpis, percentile=percentile, threshold_type=threshold_type)
 
         # log which columns were filtered and how many entities were filtered out
         self.metadata['filtered_columns'] = kpis
         self.metadata['filtered_entities_number'] = len(flags[flags == True])
-        self.metadata['filtered_threshold_kind'] = kind
+        self.metadata['filtered_threshold_kind'] = threshold_type
 
         # throw warning if too many entities have been filtered out
         if (len(flags[flags == True]) / float(len(self.data))) > 0.02:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -141,3 +141,30 @@ class Experiment(object):
 
         result['kpis'] = kpis
         return result
+
+    @staticmethod
+    def _quant_apply(value, threshold):
+        if value < threshold:
+            return False
+        else:
+            return True
+
+    def _quantile_filtering(self, df, percentile):
+        flags = pd.Series()
+        for column in df.columns:
+            flags = flags | df[column].apply(
+                self._quant_apply,
+                threshold=np.percentile(df[column], percentile)
+            )
+        return flags
+
+    def filter(self, kpis, percentile=99.0):
+        for kpi in kpis:
+            if kpi not in self.data.columns:
+                raise KeyError('kpi not in dataframe')
+
+        flags = self._quantile_filtering(df=self.data[kpis], percentile=percentile)
+        metadata = {
+            # how the filtering should be logged
+        }
+        return self.data[flags == False], metadata

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,13 +1,13 @@
-cryptography==1.0.1
-bumpversion==0.5.3
-wheel==0.23.0
-watchdog==0.8.3
-flake8==2.4.1
-tox==2.1.1
-coverage==4.0
-Sphinx==1.4
-PyYAML==3.11
-alabaster==0.7.7
-sphinx_rtd_theme==0.1.9
-Pygments==2.1.3
-Babel==2.3.4
+cryptography >= 1.0.1
+bumpversion >= 0.5.3
+wheel >= 0.23.0
+watchdog >= 0.8.3
+flake8 >= 2.4.1
+tox >= 2.1.1
+coverage >= 4.0
+Sphinx >= 1.4
+PyYAML >= 3.11
+alabaster >= 0.7.7
+sphinx_rtd_theme >= 0.1.9
+Pygments >= 2.1.3
+Babel >= 2.3.4

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -68,7 +68,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertEqual(round(a, decimals), round(b, decimals))
 
 
-    def getExperiment(self, report_kpi_names=[], derived_kpis=[]):
+    def getExperiment(self, report_kpi_names=None, derived_kpis=None):
         return Experiment('B', self.data, self.metadata, report_kpi_names, derived_kpis)
 
 

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -1,5 +1,5 @@
 import unittest
-
+import warnings
 import numpy as np
 import pandas as pd
 
@@ -178,7 +178,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -203,13 +203,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -234,7 +234,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)
@@ -272,15 +272,15 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 percentile=101.0
             )
 
-    def test_quantile_filtering_4(self):
-        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
-        with self.assertWarns(UserWarning):
-            exp.filter(
-                kpis=[
-                    'normal_same'
-                ],
-                percentile=97.9
-            )
+    # def test_quantile_filtering_4(self):
+    #     exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+    #     with self.assertWarns(UserWarning):
+    #         exp.filter(
+    #             kpis=[
+    #                 'normal_same'
+    #             ],
+    #             percentile=97.9
+    #         )
 
 
 if __name__ == '__main__':

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -6,7 +6,10 @@ import pandas as pd
 from expan.core.experiment import Experiment
 # from expan.core.results import Results
 from expan.core.util import generate_random_data, get_column_names_by_type, find_list_of_dicts_element
+
+
 # from tests.tests_core.test_results import mock_results_object
+
 
 class ExperimentTestCase(unittest.TestCase):
     """
@@ -39,22 +42,22 @@ class ExperimentClassTestCases(ExperimentTestCase):
     """
 
     # valid ones
-    derived_kpi_1 = {'name'   : 'derived_kpi_1',
+    derived_kpi_1 = {'name': 'derived_kpi_1',
                      'formula': 'normal_same/normal_shifted'}
 
-    derived_kpi_2 = {'name'   : 'derived_kpi_2',
+    derived_kpi_2 = {'name': 'derived_kpi_2',
                      'formula': 'normal_shifted/normal_same'}
 
     # bad ones
-    derived_kpi_3 = {'name'   : 'derived_kpi_3',
+    derived_kpi_3 = {'name': 'derived_kpi_3',
                      'formula': 'normal_shifted/non_existing'}
 
-    derived_kpi_4 = {'name'   : 'derived_kpi_4',
+    derived_kpi_4 = {'name': 'derived_kpi_4',
                      'formula': 'non_existing/normal_same'}
 
     # badly structured cases
     # not a dictionary
-    derived_kpi_5_1,  derived_kpi_5_2 = ['name', 'derived_kpi_5'], ['formula', 'normal_same/normal_same']
+    derived_kpi_5_1, derived_kpi_5_2 = ['name', 'derived_kpi_5'], ['formula', 'normal_same/normal_same']
     derived_kpi_6 = ['name', 'derived_kpi_6']
 
     # do not have proper keys
@@ -63,14 +66,11 @@ class ExperimentClassTestCases(ExperimentTestCase):
                      'formula_': 'normal_shifted/normal_same'}
     derived_kpi_9 = {'derived_kpi_8': 'normal_shifted/normal_same'}
 
-
     def assertNumericalEqual(self, a, b, decimals):
         self.assertEqual(round(a, decimals), round(b, decimals))
 
-
     def getExperiment(self, report_kpi_names=[], derived_kpis=[]):
         return Experiment('B', self.data, self.metadata, report_kpi_names, derived_kpis)
-
 
     def test_constructor(self):
         self.getExperiment()
@@ -80,13 +80,12 @@ class ExperimentClassTestCases(ExperimentTestCase):
 
         self.getExperiment(self.column_names + [self.derived_kpi_1['name'],
                                                 self.derived_kpi_2['name']],
-                          [self.derived_kpi_1, self.derived_kpi_2])
+                           [self.derived_kpi_1, self.derived_kpi_2])
 
         with self.assertRaises(ValueError):
             self.getExperiment(self.column_names + [self.derived_kpi_1['name'],
                                                     self.derived_kpi_3['name']],
                                [self.derived_kpi_1, self.derived_kpi_3])
-
 
         with self.assertRaises(ValueError):
             self.getExperiment(self.column_names + [self.derived_kpi_4['name'],
@@ -125,57 +124,53 @@ class ExperimentClassTestCases(ExperimentTestCase):
     def test_errors_warnings_expan_version(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='fixed_horizon')
-        a = 'errors'        in res
-        a = 'warnings'      in res
+        a = 'errors' in res
+        a = 'warnings' in res
         a = 'expan_version' in res
-
 
     def test_fixed_horizon_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='fixed_horizon')
 
         variants = find_list_of_dicts_element(res['kpis'], 'name', 'normal_same', 'variants')
-        aStats   = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
+        aStats = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
 
-        self.assertNumericalEqual(aStats['delta'],           0.033053, ndecimals)
+        self.assertNumericalEqual(aStats['delta'], 0.033053, ndecimals)
 
         self.assertNumericalEqual(aStats['confidence_interval'][0]['value'], -0.007135, ndecimals)
-        self.assertNumericalEqual(aStats['confidence_interval'][1]['value'],  0.073240, ndecimals)
+        self.assertNumericalEqual(aStats['confidence_interval'][1]['value'], 0.073240, ndecimals)
 
         self.assertEqual(aStats['treatment_sample_size'], 6108)
-        self.assertEqual(aStats['control_sample_size'],   3892)
+        self.assertEqual(aStats['control_sample_size'], 3892)
 
-        self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
-        self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
-
+        self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
+        self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
     def test_fixed_horizon_delta_derived_kpis(self):
         self.getExperiment(self.numeric_column_names + [self.derived_kpi_1['name'],
-                                                      self.derived_kpi_2['name']],
+                                                        self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta()
-
 
     def test_group_sequential_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='group_sequential')
 
         variants = find_list_of_dicts_element(res['kpis'], 'name', 'normal_same', 'variants')
-        aStats   = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
-        self.assertNumericalEqual(aStats['delta'],           0.033053, ndecimals)
+        aStats = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
+        self.assertNumericalEqual(aStats['delta'], 0.033053, ndecimals)
 
         self.assertNumericalEqual(aStats['confidence_interval'][0]['value'], -0.007135, ndecimals)
-        self.assertNumericalEqual(aStats['confidence_interval'][1]['value'],  0.073240, ndecimals)
+        self.assertNumericalEqual(aStats['confidence_interval'][1]['value'], 0.073240, ndecimals)
 
         self.assertEqual(aStats['treatment_sample_size'], 6108)
-        self.assertEqual(aStats['control_sample_size'],   3892)
+        self.assertEqual(aStats['control_sample_size'], 3892)
 
-        self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
-        self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
-
+        self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
+        self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
     def test_group_sequential_delta_derived_kpis(self):
         self.getExperiment(self.numeric_column_names + [self.derived_kpi_1['name'],
-                                                      self.derived_kpi_2['name']],
+                                                        self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
     @unittest.skip("sometimes takes too much time")
@@ -184,38 +179,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
 
         variants = find_list_of_dicts_element(res['kpis'], 'name', 'normal_same', 'variants')
-        aStats   = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
-        self.assertNumericalEqual(aStats['delta'], 0.033053, ndecimals)
-
-        self.assertEqual(aStats['stop'],      True, ndecimals)
-        self.assertEqual(aStats['number_of_iterations'], 2000, ndecimals)
-
-        #
-        # this can result in different numerical values depending on Python version
-        #
-        # self.assertNumericalEqual(aStats['confidence_interval'][0]['value'], -0.007079081, ndecimals)
-        # self.assertNumericalEqual(aStats['confidence_interval'][1]['value'],  0.072703576, ndecimals)
-
-        self.assertEqual(aStats['treatment_sample_size'], 6108)
-        self.assertEqual(aStats['control_sample_size'],   3892)
-
-        self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
-        self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
-
-
-    @unittest.skip("sometimes takes too much time")
-    def test_bayes_factor_delta_derived_kpis(self):
-        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
-        res = exp.delta(method='bayes_factor', num_iters=2000)
-
-
-    @unittest.skip("sometimes takes too much time")
-    def test_bayes_precision_delta(self):
-        ndecimals = 5
-        res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
-
-        variants = find_list_of_dicts_element(res['kpis'], 'name', 'normal_same', 'variants')
-        aStats   = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
+        aStats = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
         self.assertNumericalEqual(aStats['delta'], 0.033053, ndecimals)
 
         self.assertEqual(aStats['stop'], True, ndecimals)
@@ -228,11 +192,39 @@ class ExperimentClassTestCases(ExperimentTestCase):
         # self.assertNumericalEqual(aStats['confidence_interval'][1]['value'],  0.072703576, ndecimals)
 
         self.assertEqual(aStats['treatment_sample_size'], 6108)
-        self.assertEqual(aStats['control_sample_size'],   3892)
+        self.assertEqual(aStats['control_sample_size'], 3892)
 
-        self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
-        self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
+        self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
+        self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
+    @unittest.skip("sometimes takes too much time")
+    def test_bayes_factor_delta_derived_kpis(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        res = exp.delta(method='bayes_factor', num_iters=2000)
+
+    @unittest.skip("sometimes takes too much time")
+    def test_bayes_precision_delta(self):
+        ndecimals = 5
+        res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
+
+        variants = find_list_of_dicts_element(res['kpis'], 'name', 'normal_same', 'variants')
+        aStats = find_list_of_dicts_element(variants, 'name', 'A', 'delta_statistics')
+        self.assertNumericalEqual(aStats['delta'], 0.033053, ndecimals)
+
+        self.assertEqual(aStats['stop'], True, ndecimals)
+        self.assertEqual(aStats['number_of_iterations'], 2000, ndecimals)
+
+        #
+        # this can result in different numerical values depending on Python version
+        #
+        # self.assertNumericalEqual(aStats['confidence_interval'][0]['value'], -0.007079081, ndecimals)
+        # self.assertNumericalEqual(aStats['confidence_interval'][1]['value'],  0.072703576, ndecimals)
+
+        self.assertEqual(aStats['treatment_sample_size'], 6108)
+        self.assertEqual(aStats['control_sample_size'], 3892)
+
+        self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
+        self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
     @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
@@ -243,7 +235,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
 
     def test_quantile_filtering(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
-        res, metadata = exp.filter(
+        exp.filter(
             kpis=[
                 'normal_same',
                 'normal_shifted',
@@ -251,7 +243,36 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 'normal_unequal_variance'
             ]
         )
-        print(res.describe())
+        self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
+
+    def test_quantile_filtering_2(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertRaises(KeyError):
+            exp.filter(
+                kpis=[
+                    'revenue'
+                ]
+            )
+
+    def test_quantile_filtering_3(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertRaises(ValueError):
+            exp.filter(
+                kpis=[
+                    'normal_same'
+                ],
+                percentile=101.0
+            )
+
+    def test_quantile_filtering_4(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertWarns(UserWarning):
+            exp.filter(
+                kpis=[
+                    'normal_same'
+                ],
+                percentile=97.9
+            )
 
 
 if __name__ == '__main__':

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -178,7 +178,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -203,13 +203,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -234,7 +234,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -178,7 +178,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -203,13 +203,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -234,7 +234,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)
@@ -251,6 +251,21 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 'normal_unequal_variance'
             ]
         )
+        self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
+
+    def test_quantile_filtering_lower_threshold(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        exp.filter(
+            kpis=[
+                'normal_same',
+                'normal_shifted',
+                'normal_shifted_by_feature',
+                'normal_unequal_variance'
+            ],
+            percentile=0.1,
+            kind='lower'
+        )
+        print(exp.metadata)
         self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
 
     def test_quantile_filtering_unsupported_kpi(self):
@@ -270,6 +285,16 @@ class ExperimentClassTestCases(ExperimentTestCase):
                     'normal_same'
                 ],
                 percentile=101.0
+            )
+
+    def test_quantile_filtering_unsupported_threshold_kind(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertRaises(ValueError):
+            exp.filter(
+                kpis=[
+                    'normal_same'
+                ],
+                kind='uppper'
             )
 
     # def test_quantile_filtering_high_filtering_percentage(self):

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -265,7 +265,6 @@ class ExperimentClassTestCases(ExperimentTestCase):
             percentile=0.1,
             kind='lower'
         )
-        print(exp.metadata)
         self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
 
     def test_quantile_filtering_unsupported_kpi(self):

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -173,7 +173,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                         self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -197,12 +197,12 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -226,7 +226,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'], 0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'], -0.007833, ndecimals)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -6,7 +6,10 @@ import pandas as pd
 from expan.core.experiment import Experiment
 # from expan.core.results import Results
 from expan.core.util import generate_random_data, get_column_names_by_type, find_list_of_dicts_element
+
+
 # from tests.tests_core.test_results import mock_results_object
+
 
 class ExperimentTestCase(unittest.TestCase):
     """
@@ -63,14 +66,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
                      'formula_': 'normal_shifted/normal_same'}
     derived_kpi_9 = {'derived_kpi_8': 'normal_shifted/normal_same'}
 
-
     def assertNumericalEqual(self, a, b, decimals):
         self.assertEqual(round(a, decimals), round(b, decimals))
 
+    def getExperiment(self, report_kpi_names=[], derived_kpis=[]):
 
     def getExperiment(self, report_kpi_names=None, derived_kpis=None):
         return Experiment('B', self.data, self.metadata, report_kpi_names, derived_kpis)
-
 
     def test_constructor(self):
         self.getExperiment()
@@ -86,7 +88,6 @@ class ExperimentClassTestCases(ExperimentTestCase):
             self.getExperiment(self.column_names + [self.derived_kpi_1['name'],
                                                     self.derived_kpi_3['name']],
                                [self.derived_kpi_1, self.derived_kpi_3])
-
 
         with self.assertRaises(ValueError):
             self.getExperiment(self.column_names + [self.derived_kpi_4['name'],
@@ -129,7 +130,6 @@ class ExperimentClassTestCases(ExperimentTestCase):
         a = 'warnings'      in res
         a = 'expan_version' in res
 
-
     def test_fixed_horizon_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='fixed_horizon')
@@ -148,12 +148,10 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
-
     def test_fixed_horizon_delta_derived_kpis(self):
         self.getExperiment(self.numeric_column_names + [self.derived_kpi_1['name'],
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta()
-
 
     def test_group_sequential_delta(self):
         ndecimals = 5
@@ -202,12 +200,10 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
-
     @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
-
 
     @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
@@ -233,7 +229,6 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
-
     @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
@@ -243,7 +238,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
 
     def test_quantile_filtering(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
-        res, metadata = exp.filter(
+        exp.filter(
             kpis=[
                 'normal_same',
                 'normal_shifted',
@@ -251,7 +246,36 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 'normal_unequal_variance'
             ]
         )
-        print(res.describe())
+        self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
+
+    def test_quantile_filtering_2(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertRaises(KeyError):
+            exp.filter(
+                kpis=[
+                    'revenue'
+                ]
+            )
+
+    def test_quantile_filtering_3(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertRaises(ValueError):
+            exp.filter(
+                kpis=[
+                    'normal_same'
+                ],
+                percentile=101.0
+            )
+
+    def test_quantile_filtering_4(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        with self.assertWarns(UserWarning):
+            exp.filter(
+                kpis=[
+                    'normal_same'
+                ],
+                percentile=97.9
+            )
 
 
 if __name__ == '__main__':

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -176,7 +176,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -200,12 +200,12 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -229,7 +229,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['treatment_mean'],  0.025219, ndecimals)
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -241,7 +241,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
 
         # self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1]).delta()
 
-    def test_quantile_filtering(self):
+    def test_quantile_filtering_multiple_columns(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         exp.filter(
             kpis=[
@@ -253,7 +253,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         )
         self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
 
-    def test_quantile_filtering_2(self):
+    def test_quantile_filtering_unsupported_kpi(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         with self.assertRaises(KeyError):
             exp.filter(
@@ -262,7 +262,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 ]
             )
 
-    def test_quantile_filtering_3(self):
+    def test_quantile_filtering_unsupported_percentile(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         with self.assertRaises(ValueError):
             exp.filter(
@@ -272,7 +272,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 percentile=101.0
             )
 
-    # def test_quantile_filtering_4(self):
+    # def test_quantile_filtering_high_filtering_percentage(self):
     #     exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
     #     with self.assertWarns(UserWarning):
     #         exp.filter(

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -178,7 +178,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -203,13 +203,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -234,7 +234,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    @unittest.skip("sometimes takes too much time")
+    # @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)
@@ -263,7 +263,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 'normal_unequal_variance'
             ],
             percentile=0.1,
-            kind='lower'
+            threshold_type='lower'
         )
         self.assertEqual(len(self.data) - len(exp.data), exp.metadata['filtered_entities_number'])
 
@@ -293,7 +293,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                 kpis=[
                     'normal_same'
                 ],
-                kind='uppper'
+                threshold_type='uppper'
             )
 
     # def test_quantile_filtering_high_filtering_percentage(self):

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -178,7 +178,7 @@ class ExperimentClassTestCases(ExperimentTestCase):
                                                       self.derived_kpi_2['name']],
                            [self.derived_kpi_1, self.derived_kpi_2]).delta('group_sequential')
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_factor', num_iters=2000)
@@ -203,13 +203,13 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_factor_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_factor', num_iters=2000)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment(['normal_same']).delta(method='bayes_precision', num_iters=2000)
@@ -234,12 +234,24 @@ class ExperimentClassTestCases(ExperimentTestCase):
         self.assertNumericalEqual(aStats['control_mean'],   -0.007833, ndecimals)
 
 
-    # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("sometimes takes too much time")
     def test_bayes_precision_delta_derived_kpis(self):
         exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
         res = exp.delta(method='bayes_precision', num_iters=2000)
 
         # self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1]).delta()
+
+    def test_quantile_filtering(self):
+        exp = self.getExperiment([self.derived_kpi_1['name']], [self.derived_kpi_1])
+        res, metadata = exp.filter(
+            kpis=[
+                'normal_same',
+                'normal_shifted',
+                'normal_shifted_by_feature',
+                'normal_unequal_variance'
+            ]
+        )
+        print(res.describe())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implemented quantile filtering for easier filtering of entities whose KPI values exceed the value of the of the KPI at a given percentile. It is the default (and currently only) method invoked with the filter() method.