### PR TITLE
fixing sample size estimation

### DIFF
--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -165,7 +165,10 @@ def estimate_sample_size(x, mde, n, r, alpha=0.05, beta=0.2):
     if r <= 0:
         raise ValueError("Variant split ratio needs to be higher than 0.")
 
-    return n * ((stats.norm.ppf(1 - alpha / 2.) - stats.norm.ppf(beta)) ** 2 * (x.var() / (x.mean() ** 2)) * (1 + (1 / float(r)))) / (mde ** 2)
+    ppf = stats.norm.ppf
+    c1 = (ppf(1.0 - alpha/2.0) - ppf(beta))**2
+    c2 = (1.0 + r) * c1 * (1.0 + 1.0 / r)
+    return c2 * x.var() / (mde * x.mean())**2
 
 
 def chi_square(x, y, min_counts=5):

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -137,14 +137,13 @@ def sample_size(x):
     return len(x) - x_nan
 
 
-def estimate_sample_size(x, mde, n, r, alpha=0.05, beta=0.2):
+def estimate_sample_size(x, mde, r, alpha=0.05, beta=0.2):
     """
     Estimates sample size based on sample mean and variance given MDE (Minimum Detectable effect), number of variants and variant split ratio
 
     Args:
         x (pd.Series or pd.DataFrame): sample to base estimation on
         mde (float): minimum detectable effect
-        n (int): number of variants
         r (float): variant split ratio
         alpha (float): significance level
         beta (float): type II error
@@ -155,12 +154,6 @@ def estimate_sample_size(x, mde, n, r, alpha=0.05, beta=0.2):
     """
     if not isinstance(x, pd.Series) and not isinstance(x, pd.DataFrame):
         raise TypeError("Sample x needs to be either Series or DataFrame.")
-
-    if not isinstance(n, int):
-        raise TypeError("Number of variants needs to be an integer.")
-
-    if n <= 0:
-        raise ValueError("Number of variants needs to be higher than 0.")
 
     if r <= 0:
         raise ValueError("Variant split ratio needs to be higher than 0.")

--- a/tests/tests_core/test_statistics.py
+++ b/tests/tests_core/test_statistics.py
@@ -311,7 +311,7 @@ class EstimateSampleSizeTestCases(StatisticsTestCase):
             }
         )
 
-        res = statx.estimate_sample_size(x=x, mde=0.01, r=1.0, n=2)
+        res = statx.estimate_sample_size(x=x, mde=0.01, r=1.0)
 
         self.assertEqual(int(res['sample_1']), 197405)
         self.assertEqual(int(res['sample_2']), 142130)
@@ -321,35 +321,21 @@ class EstimateSampleSizeTestCases(StatisticsTestCase):
         Result of estimate_sample_size() is estimated sample size.
         """
         x = pd.Series([1, 7, 8, 9, 3, 4, 2, 0])
-        self.assertEqual(int(statx.estimate_sample_size(x=x, mde=0.01, r=1.0, n=2)), 197405)
+        self.assertEqual(int(statx.estimate_sample_size(x=x, mde=0.01, r=1.0)), 197405)
 
     def test__estimate_sample_size__x_type_error(self):
         """
         Method estimate_sample_size raises TypeError since x is a list.
         """
         x = [1, 7, 8, 9, 3, 4, 2, 0]
-        self.assertRaises(TypeError, statx.estimate_sample_size, x=x, mde=0.01, r=1.0, n=2)
-
-    def test__estimate_sample_size__n_type_error(self):
-        """
-        Method estimate_sample_size raises TypeError since n is a float.
-        """
-        x = pd.Series([1, 7, 8, 9, 3, 4, 2, 0])
-        self.assertRaises(TypeError, statx.estimate_sample_size, x=x, mde=0.01, r=1.0, n=1.5)
-
-    def test__estimate_sample_size__n_value_error(self):
-        """
-        Method estimate_sample_size raises ValueError since n is 0.
-        """
-        x = pd.Series([1, 7, 8, 9, 3, 4, 2, 0])
-        self.assertRaises(ValueError, statx.estimate_sample_size, x=x, mde=0.01, r=1.0, n=0)
+        self.assertRaises(TypeError, statx.estimate_sample_size, x=x, mde=0.01, r=1.0)
 
     def test__estimate_sample_size__r_value_error(self):
         """
         Method estimate_sample_size raises ValueError since r is 0.
         """
         x = pd.Series([1, 7, 8, 9, 3, 4, 2, 0])
-        self.assertRaises(ValueError, statx.estimate_sample_size, x=x, mde=0.01, r=0.0, n=2)
+        self.assertRaises(ValueError, statx.estimate_sample_size, x=x, mde=0.01, r=0.0)
 
 
 class AlphaToPercentilesTestCases(StatisticsTestCase):


### PR DESCRIPTION
We still don't know how to handle multiple variants.

The old version had both `n` as `r` as parameters.