### PR TITLE
fixed small typos in percentiles and doc text

### DIFF
--- a/docs/functionality.rst
+++ b/docs/functionality.rst
@@ -7,18 +7,18 @@ Functionality
 It provides the analysis functionalities.
 Currently we support **delta analysis**, **anomaly detection** and **subgroup analysis**.
 
-``core.statistics`` provides the underlying statistical functions. 
+``core.statistics`` provides the underlying statistical functions.
 These are used by the higher-level experiment module, and can also be used directly.
-Functionalities in this module includes **bootstrap**, **delta**, **chi_square**, 
+Functionalities in this module includes **bootstrap**, **delta**, **chi_square**,
 **pooled standard deviation** and **power analysis**.
 
 ``core.early_stpping`` provides early stopping algorithms.
 It supports **group sequential**, **Bayes factor** and **Bayes precision**.
 
 ``core.binning`` implements categorical and numerical **binning algorithms**.
-It supports binning implementations which can be applied to unseed data as well.
+It supports binning implementations which can be applied to unseen data as well.
 
-``core.utils`` contains supplied utility functions. 
+``core.utils`` contains supplied utility functions.
 for example, **generate random data** and **drop nan values**, among many other functions.
 
 ``core.version`` constructs versioning of the package.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -27,7 +27,7 @@ Per-entity ratio vs. ratio of totals
 
 There are two different definitions of a ratio metric (think of e.g. conversion rate, which is the ratio between the number of orders and the number of visits): 1) one that is based on the entity level or 2) ratio between the total sums.
 
-In a nutshell, one can reweight the individual **per-entity ratio** to calculate the **ratio of totals**. This enables to use the existing ``statistics.delta()`` function to calculate both ratio statistics (either using normal assumtion or bootstraping).
+In a nutshell, one can re-weight the individual **per-entity ratio** to calculate the **ratio of totals**. This enables to use the existing ``statistics.delta()`` function to calculate both ratio statistics (either using normal assumption or bootstrapping).
 
 Calculating conversion rate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ As an example let's look at how to calculate the conversion rate, which might be
 
 	\overline{CR}^{(pe)} = \frac{1}{n} \sum_{i=1}^n CR_i = \frac{1}{n} \sum_{i=1}^n \frac{O_i}{V_i}
 
-The ratio of totals is a reweighted version of :math:`CR_i` to reflect not the entities' contributions (e.g. contribution per custormer) but overall equal contributions to the conversion rate, which can be formulated as:
+The ratio of totals is a re-weighted version of :math:`CR_i` to reflect not the entities' contributions (e.g. contribution per customer) but overall equal contributions to the conversion rate, which can be formulated as:
 
 .. math::
 
@@ -47,7 +47,7 @@ The ratio of totals is a reweighted version of :math:`CR_i` to reflect not the e
 Overall as Reweighted Individual
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-One can calculate the :math:`CR^{(rt)}` from the :math:`\overline{CR}^{(pe)}` using the following weighting factor (easily proved by paper and pencile):
+One can calculate the :math:`CR^{(rt)}` from the :math:`\overline{CR}^{(pe)}` using the following weighting factor (easily proved by paper and pencil):
 
 .. math::
 
@@ -69,7 +69,7 @@ To have such functionality as a more generic approach in **ExpAn**, we can intro
 
 With this input it calculates :math:`\alpha` as described above and outputs the result of ``statistics.delta()``.
 
-**NB: At the moment, Expan always uses the reweighting trick for ratio-based KPIs.** This is how such KPIs are defined in Zalando.
+**NB: At the moment, Expan always uses the re-weighting trick for ratio-based KPIs.** This is how such KPIs are defined in Zalando.
 
 Early stopping
 ------------------------------------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -84,7 +84,7 @@ If you would like to change any of the default values, just pass them as paramet
 
 .. code-block:: python
 
-	exp.delta(method='fixed_horizon', assume_normal=True, percentiles=[2.5, 99.5])
+	exp.delta(method='fixed_horizon', assume_normal=True, percentiles=[2.5, 97.5])
 	exp.delta(method='group_sequential', estimated_sample_size=1000)
 	exp.delta(method='bayes_factor', distribution='normal')
 
@@ -93,8 +93,8 @@ You may also find the description in our :ref:`API <modindex>` page.
 
 *fixed_horizon* is the default method:
 
-	* ``assume_normal=True``: Specifies whether normal distribution assumptions can be made. A t-test is performed under normal assuption. We use bootstrapping otherwise. Bootstrapping takes considerably longer time than assuming the normality before running experiment. If we do not have an explicit reason to use it, it is almost always better to leave it off.
-	* ``percentiles=[2.5, 97.5``: A list of percentile values for confidence bounds.
+	* ``assume_normal=True``: Specifies whether normal distribution assumptions can be made. A t-test is performed under normal assumption. We use bootstrapping otherwise. Bootstrapping takes considerably longer time than assuming the normality before running experiment. If we do not have an explicit reason to use it, it is almost always better to leave it off.
+	* ``percentiles=[2.5, 97.5]``: A list of percentile values for confidence bounds.
 	* ``min_observations=20``: Minimum number of observations needed.
 	* ``nruns=10000``: Only used if assume normal is false.
 	* ``relative=False``: If relative==True, then the values will be returned as distances below and above the mean, respectively, rather than the absolute values.


### PR DESCRIPTION
Just small fixes of small typos in docs

* some spaces in the end of the sentences were removed by PyCharm (don't know how to prevent that).