### PR TITLE
changes structure for original and corrected test statistics

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -9,7 +9,7 @@ import expan.core.early_stopping as es
 import expan.core.statistics as statx
 import expan.core.correction as correction
 from expan.core.statistical_test import *
-from expan.core.results import StatisticalTestResult, MultipleTestSuiteResult, CorrectedTestStatistics
+from expan.core.results import StatisticalTestResult, MultipleTestSuiteResult, OriginalAndCorrectedTestStatistics
 
 warnings.simplefilter('always', UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
@@ -164,7 +164,8 @@ class Experiment(object):
                 if test_item.result:
                     original_analysis = test_suite_result.results[test_index]
                     corrected_analysis = self.analyze_statistical_test(test_item.test, test_method, **new_worker_args)
-                    combined_result = CorrectedTestStatistics(original_analysis.result, corrected_analysis.result)
+                    combined_result = OriginalAndCorrectedTestStatistics(original_analysis.result,
+                                                                         corrected_analysis.result)
                     original_analysis.result = combined_result
 
         logger.info("Statistical test suite analysis with {} tests, testmethod {}, correction method {} "

--- a/expan/core/results.py
+++ b/expan/core/results.py
@@ -87,7 +87,7 @@ class OriginalTestStatistics(JsonSerializable):
 
 
 class OriginalAndCorrectedTestStatistics(OriginalTestStatistics):
-    """ Additionally to OriginalTestStatistics holds orrected statistics. 
+    """ Additionally to OriginalTestStatistics holds corrected statistics. 
     This class should be used to hold additionally statistics for multiple testing.
     original_test_statistics and corrected_test_statistics should have the same type.
     

--- a/expan/core/results.py
+++ b/expan/core/results.py
@@ -76,8 +76,19 @@ class EarlyStoppingTestStatistics(SimpleTestStatistics):
         self.stop = stop
 
 
-class CorrectedTestStatistics(JsonSerializable):
-    """ Holds original and corrected statistics. This class should be used to hold statistics for multiple testing.
+class OriginalTestStatistics(JsonSerializable):
+    """ Holds original statistics without corrected statistics.
+    
+    :param original_test_statistics: test result without correction
+    :type  original_test_statistics: SimpleTestStatistics or EarlyStoppingTestStatistics
+    """
+    def __init__(self, original_test_statistics):
+        self.original_test_statistics = original_test_statistics
+
+
+class OriginalAndCorrectedTestStatistics(OriginalTestStatistics):
+    """ Additionally to OriginalTestStatistics holds orrected statistics. 
+    This class should be used to hold additionally statistics for multiple testing.
     original_test_statistics and corrected_test_statistics should have the same type.
     
     :param original_test_statistics: test result before correction
@@ -86,13 +97,13 @@ class CorrectedTestStatistics(JsonSerializable):
     :type  corrected_test_statistics: SimpleTestStatistics or EarlyStoppingTestStatistics
     """
     def __init__(self, original_test_statistics, corrected_test_statistics):
+        super(OriginalAndCorrectedTestStatistics, self).__init__(original_test_statistics)
         type1 = type(original_test_statistics)
         type2 = type(corrected_test_statistics)
         if type1 != type2:
             raise RuntimeError("Type mismatch for type " + str(type1) + " and " + str(type2))
         if not isinstance(original_test_statistics, BaseTestStatistics):
             raise RuntimeError("Input should be instances of BaseTestStatistics or its subclass")
-        self.original_test_statistics  = original_test_statistics
         self.corrected_test_statistics = corrected_test_statistics
 
 
@@ -103,7 +114,7 @@ class StatisticalTestResult(JsonSerializable):
     :param test: information about the statistical test
     :type  test: StatisticalTest
     :param result: result of this statistical test
-    :type  result: BaseTestStatistics or its subclasses or CorrectedTestStatistics
+    :type  result: OriginalTestStatistics or OriginalAndCorrectedTestStatistics
     """
     def __init__(self, test, result):
         self.test   = test

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -3,7 +3,7 @@ import warnings
 
 import numpy as np
 
-from expan.core.results import CorrectedTestStatistics
+from expan.core.results import OriginalAndCorrectedTestStatistics
 from expan.core.statistical_test import *
 from expan.core.experiment import Experiment
 from expan.core.util import generate_random_data, find_value_by_key_with_condition
@@ -206,8 +206,8 @@ class StatisticalTestSuiteTestCases(ExperimentTestCase):
 
         self.assertEqual(res_normal_same.test.kpi.name, "normal_same")
         self.assertEqual(res_derived_kpi.test.kpi.name, "derived_kpi_one")
-        self.assertTrue(isinstance(res_normal_same.result, CorrectedTestStatistics))
-        self.assertTrue(isinstance(res_derived_kpi.result, CorrectedTestStatistics))
+        self.assertTrue(isinstance(res_normal_same.result, OriginalAndCorrectedTestStatistics))
+        self.assertTrue(isinstance(res_derived_kpi.result, OriginalAndCorrectedTestStatistics))
 
         power_normal_same_before = res_normal_same.result.original_test_statistics.statistical_power
         power_normal_same_corrected = res_normal_same.result.corrected_test_statistics.statistical_power
@@ -244,8 +244,8 @@ class StatisticalTestSuiteTestCases(ExperimentTestCase):
         res_subgroup_feature_has = res.results[1]
         res_subgroup_feature_one = res.results[2]
 
-        self.assertTrue(isinstance(res_subgroup_feature_non.result, CorrectedTestStatistics))
-        self.assertTrue(isinstance(res_subgroup_feature_has.result, CorrectedTestStatistics))
+        self.assertTrue(isinstance(res_subgroup_feature_non.result, OriginalAndCorrectedTestStatistics))
+        self.assertTrue(isinstance(res_subgroup_feature_has.result, OriginalAndCorrectedTestStatistics))
         self.assertLess(res_subgroup_feature_non.result.corrected_test_statistics.statistical_power,
                         res_subgroup_feature_non.result.original_test_statistics.statistical_power)
         self.assertLess(res_subgroup_feature_has.result.corrected_test_statistics.statistical_power,

--- a/tests/tests_core/test_json_serializer.py
+++ b/tests/tests_core/test_json_serializer.py
@@ -29,7 +29,8 @@ class StatisticalTestCase(unittest.TestCase):
                                             confidence_interval,
                                             p,
                                             statistical_power)
-        statistical_test_result = StatisticalTestResult(statistical_test, simple_stats)
+        original_simple_stats = OriginalTestStatistics(simple_stats)
+        statistical_test_result = StatisticalTestResult(statistical_test, original_simple_stats)
 
         js_result = statistical_test_result.toJson()  # no error/exception should be raise
         print(js_result)    # use pytest -s to check the output if needed
@@ -81,8 +82,10 @@ class StatisticalTestCase(unittest.TestCase):
 
         statistical_test = StatisticalTest(kpi, [], variants)
 
-        test_result1 = StatisticalTestResult(statistical_test, CorrectedTestStatistics(simple_stats, simple_stats_corrected))
-        test_result2 = StatisticalTestResult(statistical_test, CorrectedTestStatistics(es_stats, es_stats_corrected))
+        test_result1 = StatisticalTestResult(statistical_test,
+                                             OriginalAndCorrectedTestStatistics(simple_stats, simple_stats_corrected))
+        test_result2 = StatisticalTestResult(statistical_test,
+                                             OriginalAndCorrectedTestStatistics(es_stats, es_stats_corrected))
         test_results = [test_result1, test_result2]
         statistical_test_results = MultipleTestSuiteResult(test_results, CorrectionMethod.BH)
 

--- a/tests/tests_core/test_results.py
+++ b/tests/tests_core/test_results.py
@@ -58,9 +58,11 @@ class StatisticalTestCase(unittest.TestCase):
         self.statistical_test_result = StatisticalTestResult(self.statistical_test, self.simple_stats_corrected)
 
         test_result1 = StatisticalTestResult(self.statistical_test,
-                                             CorrectedTestStatistics(self.simple_stats, self.simple_stats_corrected))
+                                             OriginalAndCorrectedTestStatistics(self.simple_stats,
+                                                                                self.simple_stats_corrected))
         test_result2 = StatisticalTestResult(self.statistical_test,
-                                             CorrectedTestStatistics(self.es_stats, self.es_stats_corrected))
+                                             OriginalAndCorrectedTestStatistics(self.es_stats,
+                                                                                self.es_stats_corrected))
         test_results = [test_result1, test_result2]
         self.statistical_test_results = MultipleTestSuiteResult(test_results, self.correction_method)
 
@@ -77,12 +79,12 @@ class StatisticalTestCase(unittest.TestCase):
         self.assertTrue(self.es_stats.stop)
 
     def test_corrected_test_statistics_simple(self):
-        corrected_test_statistics = CorrectedTestStatistics(self.simple_stats, self.simple_stats_corrected)
+        corrected_test_statistics = OriginalAndCorrectedTestStatistics(self.simple_stats, self.simple_stats_corrected)
         self.assertEqual(corrected_test_statistics.original_test_statistics.p, 0.04)
         self.assertEqual(corrected_test_statistics.corrected_test_statistics.p, 0.02)
 
     def test_corrected_test_statistics_early_stopping(self):
-        corrected_test_statistics = CorrectedTestStatistics(self.es_stats, self.es_stats_corrected)
+        corrected_test_statistics = OriginalAndCorrectedTestStatistics(self.es_stats, self.es_stats_corrected)
         self.assertEqual(corrected_test_statistics.original_test_statistics.p, 0.04)
         self.assertEqual(corrected_test_statistics.corrected_test_statistics.p, 0.02)
         self.assertTrue(corrected_test_statistics.original_test_statistics.stop)
@@ -93,7 +95,7 @@ class StatisticalTestCase(unittest.TestCase):
         type2 = str(type(self.es_stats_corrected))
         error_msg = "Type mismatch for type " + type1 + " and " + type2
         with self.assertRaisesRegexp(RuntimeError, error_msg):
-            CorrectedTestStatistics(self.simple_stats, self.es_stats_corrected)
+            OriginalAndCorrectedTestStatistics(self.simple_stats, self.es_stats_corrected)
 
     def test_statistical_test_results(self):
         self.assertEqual(self.statistical_test_result.test.kpi.name, 'revenue')


### PR DESCRIPTION
OriginalTestStatistics now holds original_test_statistics (of type SimpleTestStatistics or EarlyStoppingTestStatistics), OriginalAndCorrectedTestStatistics holds original_test_statistics and corrected_test_statistics (same types). 