### PR TITLE
Disable 5 tests that always fail

### DIFF
--- a/tests/tests_core/test_early_stopping.py
+++ b/tests/tests_core/test_early_stopping.py
@@ -85,6 +85,7 @@ class BayesFactorTestCases(EarlyStoppingTestCase):
     """ Test cases for the bayes_factor function in core.early_stopping."""
 
     # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("failing, don't know if it ever passed")
     def test_bayes_factor(self):
         """ Check the Bayes factor function."""
         res = es.bayes_factor(self.rand_s1, self.rand_s2, num_iters=2000)
@@ -106,6 +107,7 @@ class BayesFactorTestCases(EarlyStoppingTestCase):
         self.assertEqual(res.stop,              True)
 
     # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("failing, don't know if it ever passed")
     def test_bayes_factor_poisson(self):
         """ Check the Bayes factor function for Poisson distributions."""
         res = es.bayes_factor(self.rand_s3, self.rand_s4, distribution='poisson', num_iters=2000)
@@ -146,6 +148,7 @@ class BayesPrecisionTestCases(EarlyStoppingTestCase):
     """ Test cases for the bayes_precision function in core.early_stopping."""
 
     # @unittest.skip("sometimes takes too much time")
+    @unittest.skip("failing, don't know if it ever passed")
     def test_bayes_precision(self):
         """ Check the bayes_precision function."""
         res = es.bayes_precision(self.rand_s1, self.rand_s2, num_iters=2000)

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -141,6 +141,7 @@ class StatisticalTestTestCases(ExperimentTestCase):
         self.assertEqual(res.result.stop, False)
         self.assertEqual(res.test.kpi.name, 'normal_same')
 
+    @unittest.skip("failing, don't know if it ever passed")
     def test_bayes_factor_delta(self):
         ndecimals = 5
         res = self.getExperiment().analyze_statistical_test(self.test_normal_same,
@@ -163,6 +164,7 @@ class StatisticalTestTestCases(ExperimentTestCase):
         self.assertEqual(res.result.stop, True)
         self.assertEqual(res.test.kpi.name, 'normal_same')
 
+    @unittest.skip("failing, don't know if it ever passed")
     def test_bayes_precision_delta(self):
         ndecimals = 5
         res = self.getExperiment().analyze_statistical_test(self.test_normal_same,


### PR DESCRIPTION
These five tests always fail for me. It might be useful to skip these tests, and return later to try to fix them