### PR TITLE
Fix for the possibility that both variances are zero

### DIFF
--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -240,7 +240,8 @@ def pooled_std(std1, n1, std2, n2):
     :return: pooled standard deviation
     :type: float
     """
-    if not (0.5 < (std1 ** 2) / (std2 ** 2) < 2.):
+    if (std1 ** 2) >   2.0*(std2 ** 2) or \
+       (std1 ** 2) <   0.5*(std2 ** 2):
         warnings.warn('Sample variances differ too much to assume that population variances are equal.')
         logger.warning('Sample variances differ too much to assume that population variances are equal.')
 


### PR DESCRIPTION
If both variances are exactly zero, we shouldn't complain about them being too different. This PR fixes that. This will be relevant in some of our small numerical tests in future, and of course it could be relevant for some very small real world datasets