### PR TITLE
More powerful derived kpis

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -34,9 +34,18 @@ Equivalently, we can use the ratio of the means:
 
     \overline{CR} = \mbox{estimated conversion rate} = \frac{ \sum_{i=1}^n o_i }{ \sum_{i=1}^n s_i } = \frac{ \frac1{n} \sum_{i=1}^n o_i }{ \frac1{n} \sum_{i=1}^n s_i } = \frac{\bar{o}}{\bar{s}}
 
+As a side comment, you might be tempted to compute the ratio for each individual, :math:`\frac{o_i}{s_i}`,
+and compute the mean of those ratios, :math:`\overline{\left(\frac{o}{s}\right)_i}`.
+The problem with this is that it's an estimator with low accuracy; more formally, its variance is large.
+Intuitively, we want to compute a mean by giving greater weight to ratios which have more sessions;
+this is how we derive the formula for :math:`\overline{CR}` above.
+
 To calculate the variance of this estimate, and therefore apply a t-test, we need to compute the variance of this
 estimator. If we used the same data again, but randomly reassigned every user to a group (treatment or control),
 and recomputed :math:`\overline{CR}` many times, how would this estimate vary?
+
+We model that the :math:`s_i` are given (i.e. non-random), and the :math:`o_i` are random variables
+whose distribution is a function of :math:`s_i`.
 
 For each user, the "error" (think linear regression) is:
 
@@ -63,6 +72,15 @@ a pooled variance calculation as usual for a t-test.
 See the test named ``test_using_lots_of_AA_tests()`` within ``expan/tests/test_derived.py``
 for a demonstration of how this method gives a uniform p-value under the null;
 this confirms that the correct error rate is maintained.
+
+Finally, this method doesn't suffer from the problem described in
+`this blog post <https://towardsdatascience.com/the-second-ghost-of-experimentation-the-fallacy-of-session-based-metrics-fb65006d30ff>`_.
+In our notation, :math:`o_i` is the sum of the orders for all session for user :math:`i`.
+The method criticized in that blog post is to compute the variance estimate across every session, i.e. ignoring :math:`o_i` and instead using
+the per-session orders individually.
+That is problematic because it ignores the fact that the sessions for a given user may be correlated with each other.
+Our approach is different and follows the linear regression procedure closely,
+and therefore is more robust to these issues.
 
 Early stopping
 ------------------------------------

--- a/expan/core/early_stopping.py
+++ b/expan/core/early_stopping.py
@@ -41,8 +41,8 @@ def make_group_sequential(spending_function='obrien_fleming', estimated_sample_s
     def go(x, y, x_denominators=1, y_denominators=1):
 
         # these next too lines are wrong, but they are bug-compatible with v0.6.13 !
-        x = x / np.mean(x_denominators)
-        y = y / np.mean(y_denominators)
+        x = x / np.nanmean(x_denominators)
+        y = y / np.nanmean(y_denominators)
 
         return group_sequential(x, y, spending_function, estimated_sample_size, alpha, cap)
     return go
@@ -242,8 +242,8 @@ def _bayes_sampling(x, y, distribution='normal', num_iters=25000, inference="sam
 def make_bayes_factor(distribution='normal', num_iters=25000, inference='sampling'):
     """ Closure method for the bayes_factor"""
     def f(x, y, x_denominators = 1, y_denominators = 1):
-        x = x / np.mean(x_denominators)
-        y = y / np.mean(x_denominators)
+        x = x / np.nanmean(x_denominators)
+        y = y / np.nanmean(y_denominators)
         return bayes_factor(x, y, distribution, num_iters, inference)
     return f
 
@@ -303,8 +303,8 @@ def bayes_factor(x, y, distribution='normal', num_iters=25000, inference='sampli
 def make_bayes_precision(distribution='normal', posterior_width=0.08, num_iters=25000, inference='sampling'):
     """ Closure method for the bayes_precision"""
     def f(x, y, x_denominators = 1, y_denominators = 1):
-        x = x / np.mean(x_denominators)
-        y = y / np.mean(x_denominators)
+        x = x / np.nanmean(x_denominators)
+        y = y / np.nanmean(y_denominators)
         return bayes_precision(x, y, distribution, posterior_width, num_iters, inference)
     return f
 

--- a/expan/core/early_stopping.py
+++ b/expan/core/early_stopping.py
@@ -38,7 +38,14 @@ def obrien_fleming(information_fraction, alpha=0.05):
 
 def make_group_sequential(spending_function='obrien_fleming', estimated_sample_size=None, alpha=0.05, cap=8):
     """ A closure to the group_sequential function. """
-    return lambda x, y: group_sequential(x, y, spending_function, estimated_sample_size, alpha, cap)
+    def go(x, y, x_denominators=1, y_denominators=1):
+
+        # these next too lines are wrong, but they are bug-compatible with v0.6.13 !
+        x = x / np.mean(x_denominators)
+        y = y / np.mean(y_denominators)
+
+        return group_sequential(x, y, spending_function, estimated_sample_size, alpha, cap)
+    return go
 
 
 def group_sequential(x, y, spending_function='obrien_fleming', estimated_sample_size=None, alpha=0.05, cap=8):
@@ -234,7 +241,9 @@ def _bayes_sampling(x, y, distribution='normal', num_iters=25000, inference="sam
 
 def make_bayes_factor(distribution='normal', num_iters=25000, inference='sampling'):
     """ Closure method for the bayes_factor"""
-    def f(x, y):
+    def f(x, y, x_denominators = 1, y_denominators = 1):
+        x = x / np.mean(x_denominators)
+        y = y / np.mean(x_denominators)
         return bayes_factor(x, y, distribution, num_iters, inference)
     return f
 
@@ -293,7 +302,9 @@ def bayes_factor(x, y, distribution='normal', num_iters=25000, inference='sampli
 
 def make_bayes_precision(distribution='normal', posterior_width=0.08, num_iters=25000, inference='sampling'):
     """ Closure method for the bayes_precision"""
-    def f(x, y):
+    def f(x, y, x_denominators = 1, y_denominators = 1):
+        x = x / np.mean(x_denominators)
+        y = y / np.mean(x_denominators)
         return bayes_precision(x, y, distribution, posterior_width, num_iters, inference)
     return f
 

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -113,7 +113,7 @@ class Experiment(object):
         treatment_data = treatment_numerators / np.mean(treatment_denominators)
 
         # run the test method
-        test_statistics = worker(x=treatment_data, y=control_data)
+        test_statistics = worker(x=treatment_numerators, y=control_numerators, x_denominators = treatment_denominators, y_denominators = control_denominators)
         test_result.result = test_statistics
 
         # remove data from the result test metadata

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -100,13 +100,11 @@ class Experiment(object):
         logger.info("Control group size: {}".format(control.shape[0]))
         control_denominators   = self._get_denominators(data_for_analysis, test, test.variants.control_name)
         control_numerators   = control * control_denominators
-        control_data= control_numerators / np.mean(control_denominators)
 
         treatment        = test.variants.get_variant(data_for_analysis, test.variants.treatment_name)[test.kpi.name]
         logger.info("Treatment group size: {}".format(treatment.shape[0]))
         treatment_denominators = self._get_denominators(data_for_analysis, test, test.variants.treatment_name)
         treatment_numerators   = treatment * treatment_denominators
-        treatment_data = treatment_numerators / np.mean(treatment_denominators)
 
         # run the test method
         test_statistics = worker(x=treatment_numerators, y=control_numerators, x_denominators = treatment_denominators, y_denominators = control_denominators)
@@ -261,28 +259,6 @@ class Experiment(object):
             return False
         return True
 
-
-    def _get_weights(self, data, test, variant_name):
-        """ Perform the re-weighting trick on the selected derived kpi
-        See http://expan.readthedocs.io/en/latest/glossary.html#per-entity-ratio-vs-ratio-of-totals
-        
-        :param data: data subset by derived kpi and variant, for which the re-weighting trick should be done
-        :type  data: pd.DataFrame
-        :param test: statistical test, provides the derived kpi denominator for the re-weighting trick
-        :type  test: StatisticalTest
-        :param variant_name: variant name for data subset by kpi and variant
-        :type  variant_name: str
-        
-        :return returns re-weighted kpi values of type pd.Series
-        :rtype: pd.Series
-        """
-        if type(test.kpi) is not DerivedKPI:
-            return 1.0
-
-        x = test.variants.get_variant(data, variant_name)[test.kpi.denominator]
-        number_of_zeros_and_nans     = sum(x == 0) + np.isnan(x).sum()
-        number_of_non_zeros_and_nans = len(x) - number_of_zeros_and_nans
-        return number_of_non_zeros_and_nans / np.nansum(x) * x
 
     def _get_denominators(self, data, test, variant_name):
         if type(test.kpi) is not DerivedKPI:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -102,13 +102,15 @@ class Experiment(object):
         # get control and treatment values for the kpi
         control          = test.variants.get_variant(data_for_analysis, test.variants.control_name)[test.kpi.name]
         logger.info("Control group size: {}".format(control.shape[0]))
-        control_weight   = self._get_weights(data_for_analysis, test, test.variants.control_name)
-        control_data     = control * control_weight
+        control_denominators   = self._get_denominators(data_for_analysis, test, test.variants.control_name)
+        control_numerators   = control * control_denominators
+        control_data= control_numerators / np.mean(control_denominators)
 
         treatment        = test.variants.get_variant(data_for_analysis, test.variants.treatment_name)[test.kpi.name]
         logger.info("Treatment group size: {}".format(treatment.shape[0]))
-        treatment_weight = self._get_weights(data_for_analysis, test, test.variants.treatment_name)
-        treatment_data   = treatment * treatment_weight
+        treatment_denominators = self._get_denominators(data_for_analysis, test, test.variants.treatment_name)
+        treatment_numerators   = treatment * treatment_denominators
+        treatment_data = treatment_numerators / np.mean(treatment_denominators)
 
         # run the test method
         test_statistics = worker(x=treatment_data, y=control_data)

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -284,6 +284,12 @@ class Experiment(object):
         number_of_non_zeros_and_nans = len(x) - number_of_zeros_and_nans
         return number_of_non_zeros_and_nans / np.nansum(x) * x
 
+    def _get_denominators(self, data, test, variant_name):
+        if type(test.kpi) is not DerivedKPI:
+            return 1.0
+
+        x = test.variants.get_variant(data, variant_name)[test.kpi.denominator]
+        return x
 
     def _quantile_filtering(self, data, kpis, percentile, threshold_type):
         """ Make the filtering based on the given quantile level. 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -64,10 +64,9 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
     assert hasattr(x, '__len__')
     assert hasattr(y, '__len__')
 
-    # If the denominators are scalars, these lines will do nothing. But if they
-    # are vectors, this line will add a NaN to the numerator for each zero or
-    # NaN in the denominator:
-
+    # If the denominators are scalars, these next two lines will do nothing.
+    # But if they are vectors, this line will add a NaN to the numerator for
+    # each zero or NaN in the denominator:
     x = x / x_denominators * x_denominators
     y = y / y_denominators * y_denominators
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -1,3 +1,5 @@
+from __future__ import division # so that, under Python 2.*, integer division results in real numbers
+
 import warnings
 import logging
 
@@ -62,9 +64,22 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
     assert hasattr(x, '__len__')
     assert hasattr(y, '__len__')
 
-    # if *_denominators are not array-like (e.g. int or float), then make them so
-    if not hasattr(x_denominators, '__len__'): x_denominators = (x*0.0)+x_denominators
-    if not hasattr(y_denominators, '__len__'): y_denominators = (y*0.0)+y_denominators
+    # If the denominators are scalars, these lines will do nothing. But if they
+    # are vectors, this line will add a NaN to the numerator for each zero or
+    # NaN in the denominator:
+
+    x = x / x_denominators * x_denominators
+    y = y / y_denominators * y_denominators
+
+    # Next, any NaNs in the numerator must be 'copied' to the denominator.
+    # The next line will also convert the denominators to 'array-likes' if
+    # they are not already:
+    x_denominators = x_denominators+(x*0.0)
+    y_denominators = y_denominators+(y*0.0)
+
+    assert (np.isnan(x) == np.isnan(x_denominators)).all()
+    assert (np.isnan(y) == np.isnan(y_denominators)).all()
+
     assert hasattr(x_denominators, '__len__')
     assert hasattr(y_denominators, '__len__')
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -19,7 +19,7 @@ def make_delta(assume_normal=True, alpha=0.05, min_observations=20, nruns=10000,
     return lambda x, y, x_denominators=1, y_denominators=1: delta(x, y, x_denominators, y_denominators, assume_normal, alpha, min_observations, nruns, relative)
 
 
-def delta(x, y, x_denominators, y_denominators, assume_normal=True, alpha=0.05, min_observations=20, nruns=10000, relative=False):
+def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.05, min_observations=20, nruns=10000, relative=False):
     """ Calculates the difference of means between the samples in a statistical sense.
     Computation is done in form of treatment minus control, i.e. x-y.
     Note that NaNs are treated as if they do not exist in the data. 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -322,15 +322,23 @@ def normal_sample_difference(x, y, percentiles=[2.5, 97.5], relative=False):
     return c_i
 
 def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators, y_denominators, percentiles=[2.5, 97.5], relative=False):
-    """ Calculates the difference distribution of two normal distributions given by their samples.
+    """ Calculates the difference distribution of two distributions given by their samples.
 
-    Computation is done in form of treatment minus control.
+    Computation is done in form of treatment(**x**) minus control(**y**).
     It is assumed that the standard deviations of both distributions do not differ too much.
 
-    :param x: sample of a treatment group
-    :type  x: pd.Series or list (array-like)
-    :param y: sample of a control group
-    :type  x: pd.Series or list (array-like)
+    The estimate of the mean difference is :math:`\\frac{mean(x_{numerators})}{mean(x_{denominators})}-\\frac{mean(y_{numerators})}{mean(y_{denominators})}`.
+    For non-derived KPIs, the denominators will be exactly `1`, and hence this will simplify to :math:`mean(x_{numerators})-mean(y_{numerators})`.
+    For details on the variance calcuation, see the Glossary.
+
+    :param x_numerators: sample of a treatment group
+    :type  x_numerators: pd.Series or list (array-like)
+    :param y_numerators: sample of a control group
+    :type  y_numerators: pd.Series or list (array-like)
+    :param x_denominators: sample of a treatment group
+    :type  x_denominators: pd.Series or list (array-like), or simply 1 as an int/float if a non-derived KPI
+    :param y_denominators: sample of a control group
+    :type  y_denominators: pd.Series or list (array-like), or simply 1 as an int/float if a non-derived KPI
     :param percentiles: list of percentile values to compute
     :type  percentiles: list
     :param relative: If relative==True, then the values will be returned
@@ -342,13 +350,14 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
 
     :return: percentiles and corresponding values
     :rtype: dict with multiple entries:
-                confidence_interval
-                mean1
-                mean2
-                n1
-                n2
-                var1
-                var2
+
+              * **c_i**:        confidence_interval
+              * **mean1**:      :math:`\\frac{mean(x_{numerators})}{mean(x_{denominators})}`
+              * **mean2**:      :math:`\\frac{mean(y_{numerators})}{mean(y_{denominators})}`
+              * **n1**:         sample size of **x**, after discarding NaNs
+              * **n2**:         sample size of **y**, after discarding NaNs
+              * **var1**:       :math:`var\\left(\\frac{x_{numerators}[i] - mean1 \\cdot x_{denominators}[i]}{mean(x_{denominators})}\\right)`
+              * **var2**:       :math:`var\\left(\\frac{y_{numerators}[i] - mean2 \\cdot y_{denominators}[i]}{mean(y_{denominators})}\\right)`
     """
 
     assert isinstance(x_numerators, np.ndarray)

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -64,27 +64,35 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
     assert hasattr(x, '__len__')
     assert hasattr(y, '__len__')
 
-    # If the denominators are scalars, these next two lines will do nothing.
-    # But if they are vectors, this line will add a NaN to the numerator for
+    # If either denominator is a scalar, convert it to a
+    # list of identical entries:
+    if not hasattr(x_denominators, '__len__'):
+        x_denominators = [x_denominators] * len(x)
+    if not hasattr(y_denominators, '__len__'):
+        y_denominators = [y_denominators] * len(y)
+
+    # lengths should match
+    assert len(x) == len(x_denominators)
+    assert len(y) == len(y_denominators)
+
+    # Must be numpy arrays of floats (otherwise .isnan won't work)
+    x = np.array(x, dtype=float)
+    y = np.array(y, dtype=float)
+    x_denominators = np.array(x_denominators, dtype=float)
+    y_denominators = np.array(y_denominators, dtype=float)
+
+    # Add a NaN to the numerator for
     # each zero or NaN in the denominator:
     x = x / x_denominators * x_denominators
     y = y / y_denominators * y_denominators
 
     # Next, any NaNs in the numerator must be 'copied' to the denominator.
-    # The next line will also convert the denominators to 'array-likes' if
-    # they are not already:
     x_denominators = x_denominators+(x*0.0)
     y_denominators = y_denominators+(y*0.0)
 
+    # confirm the numerators have the same 'nan-ness' as their denominators
     assert (np.isnan(x) == np.isnan(x_denominators)).all()
     assert (np.isnan(y) == np.isnan(y_denominators)).all()
-
-    assert hasattr(x_denominators, '__len__')
-    assert hasattr(y_denominators, '__len__')
-
-    # lengths should match
-    assert len(x) == len(x_denominators)
-    assert len(y) == len(y_denominators)
 
     percentiles = [alpha * 100 / 2, 100 - alpha * 100 / 2]
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -240,7 +240,7 @@ def pooled_std(std1, n1, std2, n2):
     :return: pooled standard deviation
     :type: float
     """
-    if not (0.5 < (std1 ** 2) / (std2 ** 2) < 2.):
+    if std1 != std2 and not (0.5 < (std1 ** 2) / (std2 ** 2) < 2.):
         warnings.warn('Sample variances differ too much to assume that population variances are equal.')
         logger.warning('Sample variances differ too much to assume that population variances are equal.')
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -389,8 +389,8 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
     mean2 = np.mean(y_numerators) / np.mean(y_denominators)
     errors_1 = x_numerators - (x_denominators * mean1)
     errors_2 = y_numerators - (y_denominators * mean2)
-    std1 = np.std(errors_1 / np.mean(x_denominators))
-    std2 = np.std(errors_2 / np.mean(y_denominators))
+    std1 = np.std(errors_1 / np.mean(x_denominators), ddof=1)
+    std2 = np.std(errors_2 / np.mean(y_denominators), ddof=1)
     n1 = len(_x_ratio)
     n2 = len(_y_ratio)
 
@@ -406,8 +406,8 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
             ,   'mean2': mean2
             ,   'n1': n1
             ,   'n2': n2
-            ,   'var1': np.var(errors_1 / np.mean(x_denominators))
-            ,   'var2': np.var(errors_2 / np.mean(y_denominators))
+            ,   'var1': np.var(errors_1 / np.mean(x_denominators), ddof=1)
+            ,   'var2': np.var(errors_2 / np.mean(y_denominators), ddof=1)
             ,   'p_value': p_value
             }
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -96,11 +96,10 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
 
     percentiles = [alpha * 100 / 2, 100 - alpha * 100 / 2]
 
-    # Coercing missing values to right format
-    _x = np.array(x, dtype=float)
-    _y = np.array(y, dtype=float)
-    _x_denominators = np.array(x_denominators, dtype=float)
-    _y_denominators = np.array(y_denominators, dtype=float)
+    _x = x
+    _y = y
+    _x_denominators = x_denominators
+    _y_denominators = y_denominators
     _x_ratio = _x / _x_denominators
     _y_ratio = _y / _y_denominators
     _x_strange = _x / np.nanmean(_x_denominators)

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -81,6 +81,8 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
     _y_denominators = np.array(y_denominators, dtype=float)
     _x_ratio = _x / _x_denominators
     _y_ratio = _y / _y_denominators
+    _x_strange = _x / np.nanmean(_x_denominators)
+    _y_strange = _y / np.nanmean(_y_denominators)
 
     x_nan = np.isnan(_x_ratio).sum()
     y_nan = np.isnan(_y_ratio).sum()
@@ -113,22 +115,22 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
             mu = lots_of_info['mean1'] - lots_of_info['mean2']
         else:
             logger.info("The distribution of two samples is not normal. Performing the bootstrap.")
-            c_i, _ = bootstrap(x=_x_ratio, y=_y_ratio, percentiles=percentiles, nruns=nruns, relative=relative)
+            c_i, _ = bootstrap(x=_x_strange, y=_y_strange, percentiles=percentiles, nruns=nruns, relative=relative)
 
     if lots_of_info is not None: # correct the last few lines!!
         treatment_statistics = SampleStatistics(ss_x, lots_of_info['mean1'], lots_of_info['var1'])
         control_statistics   = SampleStatistics(ss_y, lots_of_info['mean2'], lots_of_info['var2'])
     else:
         # actually, this is a bit rubbish, only applies to bootstrap and min_observations:
-        treatment_statistics = SampleStatistics(ss_x, float(np.nanmean(_x_ratio)), float(np.nanvar(_x_ratio)))
-        control_statistics   = SampleStatistics(ss_y, float(np.nanmean(_y_ratio)), float(np.nanvar(_y_ratio)))
+        treatment_statistics = SampleStatistics(ss_x, float(np.nanmean(_x_strange)), float(np.nanvar(_x_strange)))
+        control_statistics   = SampleStatistics(ss_y, float(np.nanmean(_y_strange)), float(np.nanvar(_y_strange)))
 
     variant_statistics   = BaseTestStatistics(control_statistics, treatment_statistics)
     if lots_of_info is not None:
         p_value              = lots_of_info['p_value']
     else:
-        p_value              = compute_p_value_from_samples(_x_ratio, _y_ratio)
-    statistical_power    = compute_statistical_power_from_samples(_x_ratio, _y_ratio, alpha) # TODO: wrong
+        p_value              = compute_p_value_from_samples(_x_strange, _y_strange)
+    statistical_power    = compute_statistical_power_from_samples(_x_strange, _y_strange, alpha) # TODO: wrong
 
 
     logger.info("Delta calculation finished!")

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -306,24 +306,18 @@ def normal_sample_difference(x, y, percentiles=[2.5, 97.5], relative=False):
     :return: percentiles and corresponding values
     :rtype: dict
     """
-    # Coerce data to right format
+
+    # coerce to an array
     _x = np.array(x, dtype=float)
-    _x = _x[~np.isnan(_x)]
     _y = np.array(y, dtype=float)
-    _y = _y[~np.isnan(_y)]
-
-    # Calculate statistics
-    mean1 = np.mean(_x)
-    mean2 = np.mean(_y)
-    std1 = np.std(_x)
-    std2 = np.std(_y)
-    n1 = len(_x)
-    n2 = len(_y)
-
-    # Push calculation to normal difference function
-    return normal_difference(mean1=mean1, std1=std1, n1=n1,
-                             mean2=mean2, std2=std2, n2=n2,
-                             percentiles=percentiles, relative=relative)
+    # set denominators to 1.0
+    _x_denominators = np.array([1.0] * len(_x), dtype=float)
+    _y_denominators = np.array([1.0] * len(_y), dtype=float)
+    assert (_x_denominators == _x*0.0 + 1.0).all()
+    assert (_y_denominators == _y*0.0 + 1.0).all()
+    partial_simple_test_stats = normal_sample_weighted_difference(_x, _y, _x_denominators, _y_denominators, percentiles, relative)
+    c_i = partial_simple_test_stats['c_i']
+    return c_i
 
 def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators, y_denominators, percentiles=[2.5, 97.5], relative=False):
     """ Calculates the difference distribution of two normal distributions given by their samples.

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -450,6 +450,9 @@ def compute_p_value(mean1, std1, n1, mean2, std2, n2):
     std       = pooled_std(std1, n1, std2, n2)
     st_error  = std * np.sqrt(1. / n1 + 1. / n2)
     d_free    = n1 + n2 - 2
-    t         = mean_diff / st_error
+    if st_error == 0.0:
+        t         = np.sign(mean_diff) * 1000
+    else:
+        t         = mean_diff / st_error
     p         = stats.t.cdf(-abs(t), df=d_free) * 2
     return p

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -124,7 +124,10 @@ def delta(x, y, x_denominators, y_denominators, assume_normal=True, alpha=0.05, 
         control_statistics   = SampleStatistics(ss_y, float(np.nanmean(_y_ratio)), float(np.nanvar(_y_ratio)))
 
     variant_statistics   = BaseTestStatistics(control_statistics, treatment_statistics)
-    p_value              = compute_p_value_from_samples(_x_ratio, _y_ratio) # TODO: wrong
+    if lots_of_info is not None:
+        p_value              = lots_of_info['p_value']
+    else:
+        p_value              = compute_p_value_from_samples(_x_ratio, _y_ratio)
     statistical_power    = compute_statistical_power_from_samples(_x_ratio, _y_ratio, alpha) # TODO: wrong
 
 
@@ -395,6 +398,7 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
     c_i = normal_difference(mean1=mean1, std1=std1, n1=n1,
                              mean2=mean2, std2=std2, n2=n2,
                              percentiles=percentiles, relative=relative)
+    p_value = compute_p_value(mean1, std1, n1, mean2, std2, n2)
     return  {   'c_i':  c_i
             ,   'mean1': mean1
             ,   'mean2': mean2
@@ -402,6 +406,7 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
             ,   'n2': n2
             ,   'var1': np.var(errors_1 / np.mean(x_denominators))
             ,   'var2': np.var(errors_2 / np.mean(y_denominators))
+            ,   'p_value': p_value
             }
 
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -403,6 +403,10 @@ def normal_sample_weighted_difference(x_numerators, y_numerators, x_denominators
     assert 1 == len(set( map(len, [_x_ratio,x_numerators,x_denominators])))
     assert 1 == len(set( map(len, [_y_ratio,y_numerators,y_denominators])))
 
+    # Make sure all NaNs have been removed
+    for one_array in [_x_ratio, _y_ratio, x_numerators, y_numerators, x_denominators, y_denominators]:
+        assert not np.isnan(one_array).any()
+
     # Calculate statistics
     mean1 = np.mean(x_numerators) / np.mean(x_denominators)
     mean2 = np.mean(y_numerators) / np.mean(y_denominators)

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -18,7 +18,9 @@ def _delta_mean(x, y):
 
 def make_delta(assume_normal=True, alpha=0.05, min_observations=20, nruns=10000, relative=False):
     """ A closure to the delta function. """
-    return lambda x, y, x_denominators=1, y_denominators=1: delta(x, y, x_denominators, y_denominators, assume_normal, alpha, min_observations, nruns, relative)
+    def go(x, y, x_denominators=1, y_denominators=1):
+        return delta(x, y, x_denominators, y_denominators, assume_normal, alpha, min_observations, nruns, relative)
+    return go
 
 
 def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.05, min_observations=20, nruns=10000, relative=False):

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -105,6 +105,12 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
     _x_strange = _x / np.nanmean(_x_denominators)
     _y_strange = _y / np.nanmean(_y_denominators)
 
+    # Four variables no longer used in this function, let's delete them for simplicity
+    del x
+    del y
+    del x_denominators
+    del y_denominators
+
     x_nan = np.isnan(_x_ratio).sum()
     y_nan = np.isnan(_y_ratio).sum()
     if x_nan > 0:

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -1,120 +1,107 @@
 import expan.core.early_stopping as es
 import expan.core.statistics as statx
+from expan.core.experiment import Experiment
 
 import pytest
 
 import numpy as np
 
-worker_table = {
-    'fixed_horizon'    : statx.make_delta,
-    'group_sequential' : es.make_group_sequential,
-    'bayes_factor'     : es.make_bayes_factor,
-    'bayes_precision'  : es.make_bayes_precision
-}
+worker_table = Experiment(None).worker_table
 
-def dict_multilookup(d):
-    t = ( d.delta,
-                    d.control_statistics.sample_size, d.treatment_statistics.sample_size,
-                    d.control_statistics.mean, d.treatment_statistics.mean,
-                    d.control_statistics.variance, d.treatment_statistics.variance,
-                    d.p
-                    )
-    return t
+def tuple_approx(*elements):
+    assert isinstance(elements, tuple)
+
+    def helper_for__tuple_approx(x):
+        if not hasattr(x, '__len__'):
+            return pytest.approx(x)
+        else:
+            assert isinstance(x, tuple)
+            return tuple(helper_for__tuple_approx(element) for element in x)
+
+    return helper_for__tuple_approx(elements)
+
+def deltastats_to_friendly_tuple(ds):
+    from collections import namedtuple
+    Flat_delta_stats = namedtuple('Flat_delta_stats', 'delta p power stop control_stats treatment_stats c_i')
+    tup = Flat_delta_stats(    ds.delta,
+                ds.p,
+                ds.statistical_power,
+                ds.stop if hasattr(ds,'stop') else None,
+                (ds.control_statistics  .mean,ds.control_statistics  .sample_size,ds.control_statistics  .variance),
+                (ds.treatment_statistics.mean,ds.treatment_statistics.sample_size,ds.treatment_statistics.variance),
+                tuple(sorted(map(lambda _ : (_['percentile'],_['value']), ds.confidence_interval))),
+            )
+    return tup
+
+def very_compact_test(  expected_results,
+                        method, extra_args_for_method, extra_kwargs_for_method,
+                        x, y,
+                        x_denominators=None, y_denominators=None,
+                        ):
+    assert isinstance(expected_results, tuple)
+    worker_factory = worker_table[method]
+    worker = worker_factory(*extra_args_for_method, **extra_kwargs_for_method)
+
+    if x_denominators is None:
+        assert y_denominators is None
+        res = worker(x,y)
+    else:
+        assert y_denominators is not None
+        res = worker(x,y,x_denominators,y_denominators)
+    tup = deltastats_to_friendly_tuple(res)
+    assert tup == tuple_approx(*expected_results)
 
 def test_derived_fixed_horizon_equalweights():
-    worker = worker_table['fixed_horizon']    (   min_observations=0  )
-    x = np.array([1,2,3])
-    y = np.array([2,3,4])
-    ds = worker(x,y
-            , x_denominators=np.array([1,1,1])
-            , y_denominators=np.array([1,1,1])
-            )
-    assert dict_multilookup(ds)  \
-            == pytest.approx((-1,
-                3,3,
-                3,2,
-                0.66666666,0.66666666,
-                0.20799999999999982,
-                ))
-    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
-    assert pytest.approx(c_i) == [[('percentile', 2.5), ('value', -2.8509634034651996)], [('percentile', 97.5), ('value', 0.8509634034651992)]]
+    very_compact_test(          (-1.0,0.207999999,0.322771,None,(3.0,3,0.6666666)
+                                ,(2.0,3,0.66666666),((2.5,-2.8509634),(97.5,0.8509634))),
+                                'fixed_horizon',
+                                [], {'min_observations':0},
+                                np.array([1,2,3]),
+                                np.array([2,3,4]),
+                                np.array([1,1,1]),
+                                np.array([1,1,1]),
+                                )
 
 def test_derived_fixed_horizon_equalweights_not_1():
-    # by doubling the numerator and denominator throughout
-    # y, nothing changes in the result. As expected
-    worker = worker_table['fixed_horizon']    (   min_observations=0  )
-    x = np.array([1,2,3])
-    y = np.array([4,6,8])
-    ds = worker(x,y
-            , x_denominators=np.array([1,1,1])
-            , y_denominators=np.array([2,2,2])
-            )
-    assert dict_multilookup(ds)  \
-            == pytest.approx((-1,
-                3,3,
-                3,2,
-                0.66666666,0.66666666,
-                0.20799999999999982,
-                ))
-    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
-    assert pytest.approx(c_i) == [[('percentile', 2.5), ('value', -2.8509634034651996)], [('percentile', 97.5), ('value', 0.8509634034651992)]]
+    very_compact_test(          (-1.0,0.207999999,0.322771,None,(3.0,3,0.6666666)
+                                ,(2.0,3,0.66666666),((2.5,-2.8509634),(97.5,0.8509634))),
+                                'fixed_horizon',
+                                [], {'min_observations':0},
+                                np.array([1,2,3]),
+                                np.array([4,6,8]),
+                                np.array([1,1,1]),
+                                np.array([2,2,2]),
+                                )
 
 def test_derived_fixed_horizon_almost_same_ratio():
-    # by doubling the numerator and denominator throughout
-    # y, nothing changes in the result. As expected
-    worker = worker_table['fixed_horizon']    (   min_observations=0  )
-    x = np.array([1,2,3])
-    y = np.array([1,2,3])
-    ds = worker(x,y
-            , x_denominators=np.array([1,2,3])
-            , y_denominators=np.array([1,2,3])
-            )
-    some = dict_multilookup(ds)
-    assert some == pytest.approx((0,
-                3,3,
-                1,1,
-                0,0,
-                1.0,
-                ))
-    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
-    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(-0.0))], [('percentile', 97.5), ('value', pytest.approx(0.0))]]
+    very_compact_test(          (0.0,1.0,0.025,None,(1.0,3,0)
+                                ,(1.0,3,0),((2.5,0),(97.5,0))),
+                                'fixed_horizon',
+                                [], {'min_observations':0},
+                                np.array([1,2,3]),
+                                np.array([1,2,3]),
+                                np.array([1,2,3]),
+                                np.array([1,2,3]),
+                                )
 
 def test_derived_fixed_horizon_almost_same_ratio_morevariety():
-    # by doubling the numerator and denominator throughout
-    # y, nothing changes in the result. As expected
-    worker = worker_table['fixed_horizon']    (   min_observations=0  )
-    x = np.array([2,1,3])
-    y = np.array([1,4,6])
-    ds = worker(x,y
-            , x_denominators=np.array([2,1,3])
-            , y_denominators=np.array([1,4,6])
-            )
-    some = dict_multilookup(ds)
-    assert some == pytest.approx((0,
-                3,3,
-                1,1,
-                0,0,
-                1.0,
-                ))
-    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
-    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(-0.0))], [('percentile', 97.5), ('value', pytest.approx(0.0))]]
+    very_compact_test(          (0.0,1.0,0.025,None,(1.0,3,0)
+                                ,(1.0,3,0),((2.5,0),(97.5,0))),
+                                'fixed_horizon',
+                                [], {'min_observations':0},
+                                np.array([2,1,3]),
+                                np.array([1,4,6]),
+                                np.array([2,1,3]),
+                                np.array([1,4,6]),
+                                )
 
 def test_derived_fixed_horizon_almost_x_ratio_diff_from_y_ratio():
-    # by doubling the numerator and denominator throughout
-    # y, nothing changes in the result. As expected
-    worker = worker_table['fixed_horizon']    (   min_observations=0  )
-    x = np.array([4,2,6])
-    y = np.array([1,4,6])
-    ds = worker(x,y
-            , x_denominators=np.array([2,1,3])
-            , y_denominators=np.array([1,4,6])
-            )
-    some = dict_multilookup(ds)
-    assert some == pytest.approx((1,
-                3,3,
-                1,2,
-                0,0,
-                5.999960000210015e-12,
-                ))
-    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
-    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(1))], [('percentile', 97.5), ('value', pytest.approx(1))]]
+    very_compact_test(          (1.0,5e-12,0.4164563,None,(1.0,3,0)
+                                ,(2.0,3,0),((2.5,1),(97.5,1))),
+                                'fixed_horizon',
+                                [], {'min_observations':0},
+                                np.array([4,2,6]),
+                                np.array([1,4,6]),
+                                np.array([2,1,3]),
+                                np.array([1,4,6]),
+                                )

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -52,8 +52,9 @@ def very_compact_test(  expected_results,
     assert tup == tuple_approx(*expected_results)
 
 def test_derived_fixed_horizon_equalweights():
-    very_compact_test(          (-1.0,0.207999999,0.322771,None,(3.0,3,0.6666666)
-                                ,(2.0,3,0.66666666),((2.5,-2.8509634),(97.5,0.8509634))),
+    very_compact_test(          (   -1.0,0.2878641347266908,0.322771,None,
+                                    (3.0,3,1.0),(2.0,3,1.0),
+                                    ((2.5,-3.266957935527524),(97.5,1.2669579355275231))),
                                 'fixed_horizon',
                                 [], {'min_observations':0},
                                 np.array([1,2,3]),
@@ -63,8 +64,9 @@ def test_derived_fixed_horizon_equalweights():
                                 )
 
 def test_derived_fixed_horizon_equalweights_not_1():
-    very_compact_test(          (-1.0,0.207999999,0.322771,None,(3.0,3,0.6666666)
-                                ,(2.0,3,0.66666666),((2.5,-2.8509634),(97.5,0.8509634))),
+    very_compact_test(          (   -1.0,0.2878641347266908,0.322771,None,
+                                    (3.0,3,1.0),(2.0,3,1.0),
+                                    ((2.5,-3.266957935527524),(97.5,1.2669579355275231))),
                                 'fixed_horizon',
                                 [], {'min_observations':0},
                                 np.array([1,2,3]),

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -1,0 +1,120 @@
+import expan.core.early_stopping as es
+import expan.core.statistics as statx
+
+import pytest
+
+import numpy as np
+
+worker_table = {
+    'fixed_horizon'    : statx.make_delta,
+    'group_sequential' : es.make_group_sequential,
+    'bayes_factor'     : es.make_bayes_factor,
+    'bayes_precision'  : es.make_bayes_precision
+}
+
+def dict_multilookup(d):
+    t = ( d.delta,
+                    d.control_statistics.sample_size, d.treatment_statistics.sample_size,
+                    d.control_statistics.mean, d.treatment_statistics.mean,
+                    d.control_statistics.variance, d.treatment_statistics.variance,
+                    d.p
+                    )
+    return t
+
+def test_derived_fixed_horizon_equalweights():
+    worker = worker_table['fixed_horizon']    (   min_observations=0  )
+    x = np.array([1,2,3])
+    y = np.array([2,3,4])
+    ds = worker(x,y
+            , x_denominators=np.array([1,1,1])
+            , y_denominators=np.array([1,1,1])
+            )
+    assert dict_multilookup(ds)  \
+            == pytest.approx((-1,
+                3,3,
+                3,2,
+                0.66666666,0.66666666,
+                0.20799999999999982,
+                ))
+    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
+    assert pytest.approx(c_i) == [[('percentile', 2.5), ('value', -2.8509634034651996)], [('percentile', 97.5), ('value', 0.8509634034651992)]]
+
+def test_derived_fixed_horizon_equalweights_not_1():
+    # by doubling the numerator and denominator throughout
+    # y, nothing changes in the result. As expected
+    worker = worker_table['fixed_horizon']    (   min_observations=0  )
+    x = np.array([1,2,3])
+    y = np.array([4,6,8])
+    ds = worker(x,y
+            , x_denominators=np.array([1,1,1])
+            , y_denominators=np.array([2,2,2])
+            )
+    assert dict_multilookup(ds)  \
+            == pytest.approx((-1,
+                3,3,
+                3,2,
+                0.66666666,0.66666666,
+                0.20799999999999982,
+                ))
+    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
+    assert pytest.approx(c_i) == [[('percentile', 2.5), ('value', -2.8509634034651996)], [('percentile', 97.5), ('value', 0.8509634034651992)]]
+
+def test_derived_fixed_horizon_almost_same_ratio():
+    # by doubling the numerator and denominator throughout
+    # y, nothing changes in the result. As expected
+    worker = worker_table['fixed_horizon']    (   min_observations=0  )
+    x = np.array([1,2,3])
+    y = np.array([1,2,3])
+    ds = worker(x,y
+            , x_denominators=np.array([1,2,3])
+            , y_denominators=np.array([1,2,3])
+            )
+    some = dict_multilookup(ds)
+    assert some == pytest.approx((0,
+                3,3,
+                1,1,
+                0,0,
+                1.0,
+                ))
+    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
+    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(-0.0))], [('percentile', 97.5), ('value', pytest.approx(0.0))]]
+
+def test_derived_fixed_horizon_almost_same_ratio_morevariety():
+    # by doubling the numerator and denominator throughout
+    # y, nothing changes in the result. As expected
+    worker = worker_table['fixed_horizon']    (   min_observations=0  )
+    x = np.array([2,1,3])
+    y = np.array([1,4,6])
+    ds = worker(x,y
+            , x_denominators=np.array([2,1,3])
+            , y_denominators=np.array([1,4,6])
+            )
+    some = dict_multilookup(ds)
+    assert some == pytest.approx((0,
+                3,3,
+                1,1,
+                0,0,
+                1.0,
+                ))
+    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
+    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(-0.0))], [('percentile', 97.5), ('value', pytest.approx(0.0))]]
+
+def test_derived_fixed_horizon_almost_x_ratio_diff_from_y_ratio():
+    # by doubling the numerator and denominator throughout
+    # y, nothing changes in the result. As expected
+    worker = worker_table['fixed_horizon']    (   min_observations=0  )
+    x = np.array([4,2,6])
+    y = np.array([1,4,6])
+    ds = worker(x,y
+            , x_denominators=np.array([2,1,3])
+            , y_denominators=np.array([1,4,6])
+            )
+    some = dict_multilookup(ds)
+    assert some == pytest.approx((1,
+                3,3,
+                1,2,
+                0,0,
+                5.999960000210015e-12,
+                ))
+    c_i = sorted(map(lambda _ : sorted(_.items()), ds.confidence_interval))
+    assert c_i == [[('percentile', 2.5), ('value', pytest.approx(1))], [('percentile', 97.5), ('value', pytest.approx(1))]]

--- a/tests/test_derived.py
+++ b/tests/test_derived.py
@@ -214,6 +214,7 @@ def test_using_lots_of_AA_tests_ratio__always_1__withZeros():
 
 def test_using_lots_of_AB_tests_with_FALSE_null():
     n = TOTAL_SAMPLE_SIZE_FOR_AA_TESTS
+    BETA = 1.0005
 
     # In this test we add a small difference in effect between
     # treatment in order to confirm that the pvalues are
@@ -243,7 +244,7 @@ def test_using_lots_of_AB_tests_with_FALSE_null():
         x_num = revs[ assignments]
         x_den = sess[ assignments]
         # extract the 'treatments':
-        y_num = revs[~assignments] * 1.0005
+        y_num = revs[~assignments] * BETA
         y_den = sess[~assignments]
         # call the 'fixed_horizon' worker:
         res = worker(x_num,y_num,
@@ -252,7 +253,9 @@ def test_using_lots_of_AB_tests_with_FALSE_null():
                 )
         all_ps.append(res.p)
 
-    # The 'all_ps' should be approximately uniform between zero and one
+    # Finally, because this test has a small effect (BETA!=0), we
+    # expect the p values to be smaller than U(0,1)
+    # i.e.  P(p<\alpha)  is much greater than  \alpha
     assert 0.0001 < np.percentile(all_ps,10) < 0.001
     assert 0.005 < np.percentile(all_ps,50) < 0.02
     assert 0.20 < np.percentile(all_ps,90) < 0.30

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -364,37 +364,6 @@ class HelperMethodsTestCases(ExperimentTestCase):
         is_not_valid = exp._is_valid_for_analysis(self.data, self.test_nonsense_variant)
         self.assertFalse(is_not_valid)
 
-    # Test _get_weights
-    def test_get_weights(self):
-        exp = self.getExperiment()
-        res = exp._get_weights(self.data, self.test_normal_same, 'B')
-        self.assertEqual(res, 1.0)
-
-    # Test _get_weights for derived kpis
-    def test_get_weights_derived_kpi(self):
-        exp = self.getExperiment()
-        self.derived_kpi.make_derived_kpi(self.data)
-        res = exp._get_weights(self.data, self.test_derived_kpi, 'B')
-        self.assertTrue(isinstance(res, pd.Series))
-
-    # Test re-weighting trick with hardcoded data
-    def test_get_weights_hardcoded_data(self):
-        ndecimals = 5
-        exp = Experiment(self.metadata)
-        self.derived_kpi.make_derived_kpi(self.data_dummy_df)
-        res = exp._get_weights(self.data_dummy_df, self.test_derived_kpi, 'B')
-        self.assertAlmostEqual(res.iloc[0], 1.33333, ndecimals)
-        self.assertAlmostEqual(res.iloc[1], 0.66667, ndecimals)
-
-    # Test re-weighting trick with hardcoded data with NaN values
-    def test_get_weights_hardcoded_data_with_nan(self):
-        ndecimals = 5
-        exp = Experiment(self.metadata)
-        self.derived_kpi.make_derived_kpi(self.data_dummy_df_with_nan)
-        res = exp._get_weights(self.data_dummy_df_with_nan, self.test_derived_kpi, 'B')
-        self.assertAlmostEqual(res.iloc[0], 1.33333, ndecimals)
-        self.assertAlmostEqual(res.iloc[1], 0.66667, ndecimals)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_core/test_statistics.py
+++ b/tests/tests_core/test_statistics.py
@@ -263,9 +263,9 @@ class NormalSampleDifferenceTestCases(StatisticsTestCase):
         # Computation of normal sample difference
         result1 = statx.normal_sample_difference(sample1, sample2)
         # Checking if lower percentile of result1 is correct
-        self.assertAlmostEqual(result1[2.5], -0.53770569567692295)
+        self.assertAlmostEqual(result1[2.5], -0.53963938185557114)
         # Checking if upper percentile of result1 is correct
-        self.assertAlmostEqual(result1[97.5], -0.040755842784587965)
+        self.assertAlmostEqual(result1[97.5], -0.038822156605939739)
 
 
 class StatisticalPowerTestCases(StatisticsTestCase):

--- a/tests/tests_core/test_statistics.py
+++ b/tests/tests_core/test_statistics.py
@@ -46,9 +46,9 @@ class DeltaTestCases(StatisticsTestCase):
         value975 = find_value_by_key_with_condition(res.confidence_interval, 'percentile', 97.5, 'value')
 
         # Checking if lower percentile has right value
-        self.assertAlmostEqual(value025, -0.53770569567692295)
+        self.assertAlmostEqual(value025, -0.53963938185557114)
         # Checking if uper percentile has right value
-        self.assertAlmostEqual(value975, -0.040755842784587965)
+        self.assertAlmostEqual(value975, -0.038822156605939739)
         # Checking if sample size 1 is correct
         self.assertEqual(res.treatment_statistics.sample_size, 65)
         # Checking if sample size 2 is correct
@@ -63,8 +63,8 @@ class DeltaTestCases(StatisticsTestCase):
         value025 = find_value_by_key_with_condition(res.confidence_interval, 'percentile', 2.5, 'value')
         value975 = find_value_by_key_with_condition(res.confidence_interval, 'percentile', 97.5, 'value')
 
-        self.assertAlmostEqual(value025, -0.53770569567692295)
-        self.assertAlmostEqual(value975, -0.040755842784587965)
+        self.assertAlmostEqual(value025, -0.53963938185557114)
+        self.assertAlmostEqual(value975, -0.038822156605939739)
 
     def test__delta__nan_handling(self):
         """ Test correct handling of nans. (ignored). """
@@ -94,9 +94,9 @@ class DeltaTestCases(StatisticsTestCase):
         value975 = find_value_by_key_with_condition(res.confidence_interval, 'percentile', 97.5, 'value')
 
         # Checking if lower percentile has right value
-        self.assertAlmostEqual(value025, -0.53770569567692295)
+        self.assertAlmostEqual(value025, -0.53963938185557114)
         # Checking if uper percentile has right value
-        self.assertAlmostEqual(value975, -0.040755842784587965)
+        self.assertAlmostEqual(value975, -0.038822156605939739)
         # Checking if sample size 1 is correct
         self.assertEqual(res.treatment_statistics.sample_size, 65)
         # Checking if sample size 2 is correct


### PR DESCRIPTION
Previously, a derived KPI specified as  `X/Y` would be treated by dividing each element of `X` by the *average* value of `Y`, and then analysis would proceed on these adjusted values:

     adjusted_i = x_i / mean(Y)

This, correctly, meant that the `mean(Adjusted)` was equal the weighted mean of all the `x_i/y_i`. However the variance was overestimated and therefore less powerful. This PR improves the power

The priority in this PR is `make_delta`. This PR doesn't not attempt to apply this fix to `make_group_sequential`, as that will soon be removed and replaced by other changes that are coming. Bootstrapping is also not affected by this PR (but perhaps it should be!)