### PR TITLE
Counting bugfix and save memory

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -59,10 +59,6 @@ class Experiment(object):
             raise KeyError("There is no 'entity' column in the data.")
         if test.variants.variant_column_name not in test.data.columns:
             raise KeyError("There is no '{}' column in the data.".format(test.variants.variant_column_name))
-        if test.variants.treatment_name not in pd.unique(test.data[test.variants.variant_column_name]):
-            raise KeyError("There is no treatment with the name '{}' in the data.".format(test.variants.treatment_name))
-        if test.variants.control_name not in pd.unique(test.data[test.variants.variant_column_name]):
-            raise KeyError("There is no control with the name '{}' in the data.".format(test.variants.control_name))
 
         for feature in test.features:
             if feature.column_name not in test.data.columns:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -153,8 +153,8 @@ class Experiment(object):
         test_suite_result = MultipleTestSuiteResult([], test_suite.correction_method)
         for test in test_suite.tests:
             original_analysis = self.analyze_statistical_test(test, test_method, True, **worker_args)
-            # do not include results of the test where statistical power is -1 and if the results are None
-            if original_analysis.result and original_analysis.result.statistical_power != -1:
+            # If the statistical power is -1 *or* if the results are None, then we don't include the analysis
+            if original_analysis.result is not None and original_analysis.result.statistical_power != -1:
                 combined_result = CombinedTestStatistics(original_analysis.result, original_analysis.result)
                 original_analysis.result = combined_result
                 test_suite_result.results.append(original_analysis)

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -253,11 +253,13 @@ class Experiment(object):
         :return True if data is valid for analysis and False if not
         :rtype: bool 
         """
-        if len(data[data[test.variants.variant_column_name] == test.variants.control_name].dropna()) <= 1:
-            logger.warning("Control group only contains 1 or 0 entities.")
+        count_controls   = sum(data[test.variants.variant_column_name] == test.variants.control_name)
+        count_treatments = sum(data[test.variants.variant_column_name] == test.variants.treatment_name)
+        if count_controls <= 1:
+            logger.warning("Control group only contains {} entities.".format(count_controls))
             return False
-        if len(data[data[test.variants.variant_column_name] == test.variants.treatment_name].dropna()) <= 1:
-            logger.warning("Treatment group only contains 1 or 0 entities.")
+        if count_treatments <= 1:
+            logger.warning("Treatment group only contains {} entities.".format(count_treatments))
             return False
         return True
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -457,9 +457,6 @@ def compute_p_value(mean1, std1, n1, mean2, std2, n2):
     if min(n1,n2) < 1 or max(n1,n2) < 2:
         return np.nan
 
-    assert min(n1,n2) >= 1
-    assert max(n1,n2) >= 2
-
     mean_diff = mean1 - mean2
     std       = pooled_std(std1, n1, std2, n2)
     st_error  = std * np.sqrt(1. / n1 + 1. / n2)

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -395,7 +395,7 @@ def compute_statistical_power(mean1, std1, n1, mean2, std2, n2, z_1_minus_alpha)
     effect_size = mean1 - mean2
     std = pooled_std(std1, n1, std2, n2)
     if std <= 0.0:
-        logger.error("Zero pooled std in compute_statistical_power.")
+        logger.warning("Zero pooled std in compute_statistical_power.")
         return -1
 
     tmp = (n1 * n2 * effect_size**2) / ((n1 + n2) * std**2)

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -387,6 +387,11 @@ def compute_statistical_power(mean1, std1, n1, mean2, std2, n2, z_1_minus_alpha)
                                     or -1 if std is less or equal to 0
     :rtype: float
     """
+
+    # First, check we have enough data for a t-test:
+    if min(n1,n2) < 1 or max(n1,n2) < 2:
+        return -1
+
     effect_size = mean1 - mean2
     std = pooled_std(std1, n1, std2, n2)
     if std <= 0.0:
@@ -447,6 +452,14 @@ def compute_p_value(mean1, std1, n1, mean2, std2, n2):
     :return: two-tailed p-value 
     :rtype: float
     """
+
+    # First, check if we have enough data to do a t-test
+    if min(n1,n2) < 1 or max(n1,n2) < 2:
+        return np.nan
+
+    assert min(n1,n2) >= 1
+    assert max(n1,n2) >= 2
+
     mean_diff = mean1 - mean2
     std       = pooled_std(std1, n1, std2, n2)
     st_error  = std * np.sqrt(1. / n1 + 1. / n2)


### PR DESCRIPTION
Save memory by counting only in the 'variant' Series directly.

Also, fix a bug where rows were ignored (for the purpose of this check) if they had NA is any other column

And stop throwing `KeyError` if control/treatment are underrepresented, this was an important issue

And finally, give a `warning` - instead of an `error` - if there are too few datapoints.