### PR TITLE
Re-wrote chi-square, removed dropping buckets.

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -337,7 +337,7 @@ class Experiment(object):
         expected_freqs = pd.Series(weights)
         expected_freqs *= total_count
 
-        #     chi-square and p-value statistics
+        # Compute chi-square and p-value statistics
         chi_square_val, p_val = statx.chi_square(observed_freqs.sort_index(), expected_freqs.sort_index())
 
         return p_val >= alpha, p_val, chi_square_val

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -319,14 +319,13 @@ class Experiment(object):
 
         # Count number of observations per each variant
         variant_column = pd.Series(variant_column).dropna(axis=0)
-        variants_counts = variant_column.value_counts()
+        observed_freqs = variant_column.value_counts()
 
         # Ensure at least a frequency of 5 at every location in observed_counts.
         # It's recommended to not conduct test if frequencies in each category is less than 5
-        if len(variants_counts[variants_counts < min_counts]) >= 1:
+        if len(observed_freqs[observed_freqs < min_counts]) >= 1:
             raise ValueError("Chi-square test is not valid for small expected or observed frequencies.")
 
-        observed_freqs = variants_counts
         # If there are less than 2 categories left after dropping counts less than 5 we can't conduct the test.
         if len(observed_freqs) < 2:
             raise ValueError("If the number of categories is less than 2 Chi-square test is not applicable.")

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -226,6 +226,10 @@ class Experiment(object):
         # log which columns were filtered and how many entities were filtered out
         self.metadata['filtered_columns'] = [kpi.name for kpi in kpis]
         self.metadata['filtered_entities_number'] = len(flags[flags == True])
+
+        filtered = [item[1] for item in list(zip(flags, data['variant'])) if item[0] == True]
+        self.metadata['filtered_entities_per_variant'] = dict((val, filtered.count(val)) for val in set(filtered))
+
         self.metadata['filtered_threshold_kind'] = threshold_type
         # throw warning if too many entities have been filtered out
         if (len(flags[flags == True]) / float(len(data))) > 0.02:

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -321,8 +321,8 @@ class Experiment(object):
         variant_column = pd.Series(variant_column).dropna(axis=0)
         observed_freqs = variant_column.value_counts()
 
-        # Ensure at least a frequency of 5 at every location in observed_counts.
-        # It's recommended to not conduct test if frequencies in each category is less than 5
+        # Ensure at least a frequency of min_counts at every location in observed_counts.
+        # It's recommended to not conduct test if frequencies in each category is less than min_counts
         if len(observed_freqs[observed_freqs < min_counts]) >= 1:
             raise ValueError("Chi-square test is not valid for small expected or observed frequencies.")
 
@@ -338,7 +338,6 @@ class Experiment(object):
         expected_freqs *= total_count
 
         #     chi-square and p-value statistics
-        chi_square_val, p_val = statx.chi_square(observed_freqs.sort_index(), expected_freqs.sort_index(),
-                                                 len(observed_freqs)-1)
+        chi_square_val, p_val = statx.chi_square(observed_freqs.sort_index(), expected_freqs.sort_index())
 
         return p_val >= alpha, p_val, chi_square_val

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -321,10 +321,12 @@ class Experiment(object):
         variant_column = pd.Series(variant_column).dropna(axis=0)
         variants_counts = variant_column.value_counts()
 
-        # Ensure at least a frequency of 5 at every location in observed_counts, otherwise drop the category
-        # see http://docs.scipy.org/doc/scipy-0.16.1/reference/generated/scipy.stats.chisquare.html
-        observed_freqs = variants_counts[variants_counts >= min_counts]
+        # Ensure at least a frequency of 5 at every location in observed_counts.
+        # It's recommended to not conduct test if frequencies in each category is less than 5
+        if len(variants_counts[variants_counts < min_counts]) >= 1:
+            raise ValueError("Chi-square test is not valid for small expected or observed frequencies.")
 
+        observed_freqs = variants_counts
         # If there are less than 2 categories left after dropping counts less than 5 we can't conduct the test.
         if len(observed_freqs) < 2:
             raise ValueError("If the number of categories is less than 2 Chi-square test is not applicable.")
@@ -336,7 +338,8 @@ class Experiment(object):
         expected_freqs = pd.Series(weights)
         expected_freqs *= total_count
 
-        # Compute chi-square and p-value statistics
-        chi_square_val, p_val = statx.chi_square(observed_freqs.sort_index(), expected_freqs.sort_index())
+        #     chi-square and p-value statistics
+        chi_square_val, p_val = statx.chi_square(observed_freqs.sort_index(), expected_freqs.sort_index(),
+                                                 len(observed_freqs)-1)
 
         return p_val >= alpha, p_val, chi_square_val

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -631,20 +631,19 @@ def compute_p_value(mean1, std1, n1, mean2, std2, n2):
     return p
 
 
-def chi_square(observed_freqs, expected_freqs, dof):
+def chi_square(observed_freqs, expected_freqs, ddof=0):
     """ Compute chi-square statistics and p-values given observed and expected frequencies and degrees of freedom. 
 
     :param observed_freqs: observed frequencies 
     :type  observed_freqs: pd.Series or array-like
     :param expected_freqs: expected frequencies
     :type  expected_freqs: pd.Series or array-like
-    :param dof: delta degrees of freedom: number of categories/buckets - 1
-    :type  dof: int
+    :param ddof: delta degrees of freedom, 0 by default
+    :type  ddof: int
     
     :return: chi-square statistics and p-value
     :rtype:  float, float
     """
-    chi_square_val = sum([(o - e)**2 / float(e) for o, e in zip(observed_freqs, expected_freqs)])
-    p_val = 1 - stats.chi2.cdf(chi_square_val, dof)
+    chi_square_val, p_val = stats.chisquare(f_obs=observed_freqs, f_exp=expected_freqs, ddof=ddof, axis=None)
 
     return chi_square_val, p_val

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -638,7 +638,7 @@ def chi_square(observed_freqs, expected_freqs, dof):
     :type  observed_freqs: pd.Series or array-like
     :param expected_freqs: expected frequencies
     :type  expected_freqs: pd.Series or array-like
-    :param dof: delta degrees of freedom, 0 by default
+    :param dof: delta degrees of freedom: number of categories/buckets - 1
     :type  dof: int
     
     :return: chi-square statistics and p-value

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -139,7 +139,10 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
         if assume_normal:
             logger.info("The distribution of two samples is assumed normal. "
                         "Performing the sample difference distribution calculation.")
-            partial_simple_test_stats = normal_sample_weighted_difference(x_numerators=_x, y_numerators=_y, x_denominators=_x_denominators, y_denominators = _y_denominators, percentiles=percentiles, relative=relative)
+            partial_simple_test_stats = normal_sample_weighted_difference(x_numerators=_x, y_numerators=_y,
+                                                                          x_denominators=_x_denominators,
+                                                                          y_denominators=_y_denominators,
+                                                                          percentiles=percentiles, relative=relative)
             c_i = partial_simple_test_stats['c_i']
             mu = partial_simple_test_stats['mean1'] - partial_simple_test_stats['mean2']
         else:
@@ -154,13 +157,12 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
         treatment_statistics = SampleStatistics(ss_x, float(np.nanmean(_x_strange)), float(np.nanvar(_x_strange)))
         control_statistics   = SampleStatistics(ss_y, float(np.nanmean(_y_strange)), float(np.nanvar(_y_strange)))
 
-    variant_statistics   = BaseTestStatistics(control_statistics, treatment_statistics)
+    variant_statistics = BaseTestStatistics(control_statistics, treatment_statistics)
     if partial_simple_test_stats is not None:
-        p_value              = partial_simple_test_stats['p_value']
+        p_value = partial_simple_test_stats['p_value']
     else:
-        p_value              = compute_p_value_from_samples(_x_strange, _y_strange)
-    statistical_power    = compute_statistical_power_from_samples(_x_strange, _y_strange, alpha) # TODO: wrong
-
+        p_value = compute_p_value_from_samples(_x_strange, _y_strange)
+    statistical_power = compute_statistical_power_from_samples(_x_strange, _y_strange, alpha) # TODO: wrong
 
     logger.info("Delta calculation finished!")
     return SimpleTestStatistics(variant_statistics.control_statistics,
@@ -629,18 +631,20 @@ def compute_p_value(mean1, std1, n1, mean2, std2, n2):
     return p
 
 
-def chi_square(observed_freqs, expected_freqs, ddof=0):
+def chi_square(observed_freqs, expected_freqs, dof):
     """ Compute chi-square statistics and p-values given observed and expected frequencies and degrees of freedom. 
 
     :param observed_freqs: observed frequencies 
     :type  observed_freqs: pd.Series or array-like
     :param expected_freqs: expected frequencies
     :type  expected_freqs: pd.Series or array-like
-    :param ddof: delta degrees of freedom, 0 by default
-    :type  ddof: int
+    :param dof: delta degrees of freedom, 0 by default
+    :type  dof: int
     
     :return: chi-square statistics and p-value
     :rtype:  float, float
     """
-    chi_square_val, p_val = stats.chisquare(f_obs=observed_freqs, f_exp=expected_freqs, ddof=ddof, axis=None)
+    chi_square_val = sum([(o - e)**2 / float(e) for o, e in zip(observed_freqs, expected_freqs)])
+    p_val = 1 - stats.chi2.cdf(chi_square_val, dof)
+
     return chi_square_val, p_val

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -301,6 +301,10 @@ class OutlierFilteringTestCases(ExperimentTestCase):
             threshold_type='upper'
         )
         self.assertEqual(len(flags[flags==True]), 386)
+        filtered = [item[1] for item in list(zip(flags, self.data['variant'])) if item[0] == True]
+        filtered_dict = dict((val, filtered.count(val)) for val in set(filtered))
+        self.assertEqual(filtered_dict['A'], 88)
+        self.assertEqual(filtered_dict['B'], 298)
 
     def test_outlier_filtering_lower_threshold(self):
         exp = self.getExperiment()
@@ -316,6 +320,8 @@ class OutlierFilteringTestCases(ExperimentTestCase):
             threshold_type='lower'
         )
         self.assertEqual(len(self.data) - len(data), exp.metadata['filtered_entities_number'])
+        self.assertEqual(exp.metadata['filtered_entities_per_variant']['A'], 22)
+        self.assertEqual(exp.metadata['filtered_entities_per_variant']['B'], 18)
 
     def test_outlier_filtering_unsupported_kpi(self):
         exp = self.getExperiment()

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -387,21 +387,19 @@ class OutlierFilteringTestCases(ExperimentTestCase):
         with self.assertRaises(ValueError):
             exp.chi_square_test_result_and_statistics(data, weights)
 
-    def test_chi_square_test_result_and_statistics_counts_less_5_1_category(self):
+    def test_chi_square_test_result_and_statistics_counts_less_5_2_categories(self):
         exp = self.getExperiment()
         data = ['A'] * 17 + ['B'] * 2 + ['C'] * 3
         weights = {'A': 0.33, 'B': 0.33, 'C': 0.33}
         with self.assertRaises(ValueError):
             exp.chi_square_test_result_and_statistics(data, weights)
 
-    def test_chi_square_test_result_and_statistics_counts_less_5_2_categories(self):
+    def test_chi_square_test_result_and_statistics_counts_less_5_1_category(self):
         exp = self.getExperiment()
-        data = ['A'] * 17 + ['B'] * 15 + ['C'] * 3
+        data = ['A'] * 8 + ['B'] * 2 + ['C'] * 14
         weights = {'A': 0.33, 'B': 0.33, 'C': 0.33}
-        result = exp.chi_square_test_result_and_statistics(data, weights)
-        self.assertEqual(result[0], False)
-        self.assertAlmostEqual(result[1], 0.0160787417516)
-        self.assertAlmostEqual(result[2], 5.794242424242423)
+        with self.assertRaises(ValueError):
+            exp.chi_square_test_result_and_statistics(data, weights)
 
     def test_chi_square_test_result_and_statistics_one_category(self):
         exp = self.getExperiment()


### PR DESCRIPTION
As discussed I removed category dropping (now we don't drop any categories), min_counts is input parameter (I set it to 5 as default), but in ADS afterward we will decide which threshold to use.
Also added number of filtered entities per variant in exp.metadata.