### PR TITLE
Remove some logging. Perhaps make it optional?

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -72,11 +72,6 @@ class Experiment(object):
                 raise KeyError("Denominator '{}' of the derived KPI does not exist in the data.".format(test.kpi.denominator))
             test.kpi.make_derived_kpi(test.data)
 
-        logger.info("One analysis with kpi '{}', control variant '{}', treatment variant '{}' and features [{}] "
-                    "has just started".format(test.kpi, test.variants.control_name,
-                                              test.variants.treatment_name,
-                                              [(feature.column_name, feature.column_value) for feature in test.features]))
-
         if test_method not in self.worker_table:
             raise NotImplementedError("Test method '{}' is not implemented.".format(test_method))
         worker = self.worker_table[test_method](**worker_args)
@@ -96,12 +91,10 @@ class Experiment(object):
 
         # get control and treatment values for the kpi
         control          = test.variants.get_variant(data_for_analysis, test.variants.control_name)[test.kpi.name]
-        logger.info("Control group size: {}".format(control.shape[0]))
         control_denominators   = self._get_denominators(data_for_analysis, test, test.variants.control_name)
         control_numerators   = control * control_denominators
 
         treatment        = test.variants.get_variant(data_for_analysis, test.variants.treatment_name)[test.kpi.name]
-        logger.info("Treatment group size: {}".format(treatment.shape[0]))
         treatment_denominators = self._get_denominators(data_for_analysis, test, test.variants.treatment_name)
         treatment_numerators   = treatment * treatment_denominators
 

--- a/expan/core/statistics.py
+++ b/expan/core/statistics.py
@@ -115,12 +115,6 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
 
     x_nan = np.isnan(_x_ratio).sum()
     y_nan = np.isnan(_y_ratio).sum()
-    if x_nan > 0:
-        warnings.warn('Discarding ' + str(x_nan) + ' NaN(s) in the x array!')
-        logger.warning('Discarding ' + str(x_nan) + ' NaN(s) in the x array!')
-    if y_nan > 0:
-        warnings.warn('Discarding ' + str(y_nan) + ' NaN(s) in the y array!')
-        logger.warning('Discarding ' + str(x_nan) + ' NaN(s) in the x array!')
 
     ss_x = sample_size(_x_ratio)
     ss_y = sample_size(_y_ratio)
@@ -137,8 +131,6 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
         mu = _delta_mean(_x, _y)
         # Computing the confidence intervals
         if assume_normal:
-            logger.info("The distribution of two samples is assumed normal. "
-                        "Performing the sample difference distribution calculation.")
             partial_simple_test_stats = normal_sample_weighted_difference(x_numerators=_x, y_numerators=_y,
                                                                           x_denominators=_x_denominators,
                                                                           y_denominators=_y_denominators,
@@ -164,7 +156,6 @@ def delta(x, y, x_denominators=1, y_denominators=1, assume_normal=True, alpha=0.
         p_value = compute_p_value_from_samples(_x_strange, _y_strange)
     statistical_power = compute_statistical_power_from_samples(_x_strange, _y_strange, alpha) # TODO: wrong
 
-    logger.info("Delta calculation finished!")
     return SimpleTestStatistics(variant_statistics.control_statistics,
                                 variant_statistics.treatment_statistics,
                                 float(mu), c_i, p_value, statistical_power)
@@ -308,11 +299,6 @@ def pooled_std(std1, n1, std2, n2):
     :return: pooled standard deviation
     :type: float
     """
-
-    if (std1 ** 2) >   2.0*(std2 ** 2) or \
-       (std1 ** 2) <   0.5*(std2 ** 2):
-        warnings.warn('Sample variances differ too much to assume that population variances are equal.')
-        logger.warning('Sample variances differ too much to assume that population variances are equal.')
 
     return np.sqrt(((n1 - 1) * std1 ** 2 + (n2 - 1) * std2 ** 2) / (n1 + n2 - 2))
 

--- a/tests/tests_core/test_statistics.py
+++ b/tests/tests_core/test_statistics.py
@@ -199,15 +199,6 @@ class BootstrapTestCases(StatisticsTestCase):
 
 
 class PooledStdTestCases(StatisticsTestCase):
-    def test__pooled_std__variances_differ_too_much_error(self):
-        """ Warning raised when variances differ too much. """
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            statx.pooled_std(0.25, 4, 0.5, 4)
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertTrue('variances differ' in str(w[-1].message))
-
     def test__pooled_std__computation(self):
         """ Result of pooled_std() equals expected result. """
         # Define subset of data for test


### PR DESCRIPTION
These messages seem to be the most repetitive. Also, they don't seem very useful to me

So this PR proposes to remove them. If they are valuable, we could consider making them optional

Also, even if somebody does want to record the number of NaNs, the current message is kinda of useless and is not concise. I would prefer to log a simple, concise, report of the number of NaNs is each column