### PR TITLE
If the number of *finite* samples is too small, then the data isn't valid for analysis

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -99,13 +99,11 @@ class Experiment(object):
 
         # get control and treatment values for the kpi
         control          = test.variants.get_variant(data_for_analysis, test.variants.control_name)[test.kpi.name]
-        control          = np.array (control, dtype=np.float64)
         logger.info("Control group size: {}".format(control.shape[0]))
         control_denominators   = self._get_denominators(data_for_analysis, test, test.variants.control_name)
         control_numerators   = control * control_denominators
 
         treatment        = test.variants.get_variant(data_for_analysis, test.variants.treatment_name)[test.kpi.name]
-        treatment        = np.array (treatment, dtype=np.float64)
         logger.info("Treatment group size: {}".format(treatment.shape[0]))
         treatment_denominators = self._get_denominators(data_for_analysis, test, test.variants.treatment_name)
         treatment_numerators   = treatment * treatment_denominators

--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -99,11 +99,13 @@ class Experiment(object):
 
         # get control and treatment values for the kpi
         control          = test.variants.get_variant(data_for_analysis, test.variants.control_name)[test.kpi.name]
+        control          = np.array (control, dtype=np.float64)
         logger.info("Control group size: {}".format(control.shape[0]))
         control_denominators   = self._get_denominators(data_for_analysis, test, test.variants.control_name)
         control_numerators   = control * control_denominators
 
         treatment        = test.variants.get_variant(data_for_analysis, test.variants.treatment_name)[test.kpi.name]
+        treatment        = np.array (treatment, dtype=np.float64)
         logger.info("Treatment group size: {}".format(treatment.shape[0]))
         treatment_denominators = self._get_denominators(data_for_analysis, test, test.variants.treatment_name)
         treatment_numerators   = treatment * treatment_denominators
@@ -273,10 +275,10 @@ class Experiment(object):
 
     def _get_denominators(self, data, test, variant_name):
         if type(test.kpi) is not DerivedKPI:
-            return 1.0
+            return np.float64(1.0)
 
         x = test.variants.get_variant(data, variant_name)[test.kpi.denominator]
-        return x
+        return np.array(x, dtype=np.float64)
 
 
     def _quantile_filtering(self, data, kpis, percentile, threshold_type):

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -76,11 +76,12 @@ class ExperimentTestCase(unittest.TestCase):
         self.suite_with_one_test_zero_std = StatisticalTestSuite([self.test_normal_same_zero_std])
 
         # small dummy data frames with all nan values
-        data_dummy_all_nan = np.array([['index', 'entity', 'variant', 'normal_same', 'normal_shifted'],
-                                       [0, 1, 'A', np.nan, np.nan], [1, 2, 'B', np.nan, np.nan],
-                                       [2, 3, 'A', np.nan, np.nan], [3, 4, 'B', np.nan, np.nan]])
-        self.data_dummy_all_nan = pd.DataFrame(data=data_dummy_all_nan[1:, 1:],
-                                               columns=data_dummy_all_nan[0, 1:]).convert_objects(convert_numeric=True)
+        self.data_dummy_all_nan = pd.DataFrame({
+                        'entity' : [1,2,3,4],
+                        'variant' : ['A','B','C','D'],
+                        'normal_same' : [np.nan] * 4,
+                        'normal_shifted' : [np.nan] * 4,
+                            })
         self.test_normal_same_nan_data = StatisticalTest(self.data_dummy_all_nan, self.kpi, [], self.variants)
         self.suite_with_one_test_with_nan_data = StatisticalTestSuite([self.test_normal_same_nan_data])
 

--- a/tests/tests_core/test_experiment.py
+++ b/tests/tests_core/test_experiment.py
@@ -77,8 +77,8 @@ class ExperimentTestCase(unittest.TestCase):
 
         # small dummy data frames with all nan values
         data_dummy_all_nan = np.array([['index', 'entity', 'variant', 'normal_same', 'normal_shifted'],
-                                       [0, 1, 'A', None, None], [1, 2, 'B', None, None],
-                                       [2, 3, 'A', None, None], [3, 4, 'B', None, None]])
+                                       [0, 1, 'A', np.nan, np.nan], [1, 2, 'B', np.nan, np.nan],
+                                       [2, 3, 'A', np.nan, np.nan], [3, 4, 'B', np.nan, np.nan]])
         self.data_dummy_all_nan = pd.DataFrame(data=data_dummy_all_nan[1:, 1:],
                                                columns=data_dummy_all_nan[0, 1:]).convert_objects(convert_numeric=True)
         self.test_normal_same_nan_data = StatisticalTest(self.data_dummy_all_nan, self.kpi, [], self.variants)
@@ -278,7 +278,7 @@ class StatisticalTestSuiteTestCases(ExperimentTestCase):
         self.assertEqual(res.correction_method, CorrectionMethod.NONE)
         self.assertEqual(len(res.results), 0)
 
-    def test_analyze_statistical_test_with_none_data(self):
+    def test_analyze_statistical_test_with_nan_data(self):
         res = self.getExperiment().analyze_statistical_test_suite(self.suite_with_one_test_with_nan_data)
         self.assertEqual(res.correction_method, CorrectionMethod.NONE)
         self.assertEqual(len(res.results), 0)


### PR DESCRIPTION
This is to fix a bug which the number of *finite* samples (non-NaN, non-inf) is too small.

(we should add units tests for this too)