### PR TITLE
stop overriding the warning level

### DIFF
--- a/expan/core/experiment.py
+++ b/expan/core/experiment.py
@@ -10,7 +10,6 @@ import expan.core.correction as correction
 from expan.core.statistical_test import *
 from expan.core.results import StatisticalTestResult, MultipleTestSuiteResult, CombinedTestStatistics
 
-warnings.simplefilter('always', UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 logger = logging.getLogger(__name__)
 

--- a/tests/tests_core/test_statistics.py
+++ b/tests/tests_core/test_statistics.py
@@ -8,6 +8,7 @@ import expan.core.statistics as statx
 from expan.core.util import find_value_by_key_with_condition
 from .util import *
 
+warnings.simplefilter('always')
 
 class StatisticsTestCase(unittest.TestCase):
     def setUp(self):
@@ -202,7 +203,6 @@ class PooledStdTestCases(StatisticsTestCase):
     def test__pooled_std__variances_differ_too_much_error(self):
         """ Warning raised when variances differ too much. """
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
             statx.pooled_std(0.25, 4, 0.5, 4)
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, UserWarning))


### PR DESCRIPTION
stop overriding the warning level, in order to allow the users to decide it themselves (via the -W option to 'python' for example)

For most users, this means they will see each warning only one. They can modify this themselves if they want

By removing this line, the `-W` option (see [here](https://docs.python.org/2/using/cmdline.html#cmdoption-w)) can take effect.