### PR TITLE
Correct documentation

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -12,9 +12,10 @@ Assumptions used in analysis
   * Variance in treatment and control is identical
   * Mean of delta is normally distributed
 
-2. Welch t-test
+2. Equal or unequal sample sizes, equal variance t-test
 
   * Mean of means is t-distributed (or normally distributed)
+  * Variance of two distributions are same (so the variance of two groups of sample should be similar)
 
 3. In general
 

--- a/requirements_tox_test.txt
+++ b/requirements_tox_test.txt
@@ -5,4 +5,3 @@ numpy == 1.13.1
 simplejson == 3.11.1
 pystan == 2.16.0.0
 enum34 == 1.1.6
-pytest-cov < 2.6.0

--- a/requirements_tox_test.txt
+++ b/requirements_tox_test.txt
@@ -5,3 +5,4 @@ numpy == 1.13.1
 simplejson == 3.11.1
 pystan == 2.16.0.0
 enum34 == 1.1.6
+pytest-cov < 2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,6 @@ commands =
 	py.test --cov=expan tests
 deps =
     pytest==3.0.7
-	pytest-cov
+	pytest-cov = 2.6.0
 	-r{toxinidir}/requirements_tox_test.txt
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,6 @@ commands =
 	py.test --cov=expan tests
 deps =
     pytest==3.0.7
-	pytest-cov = 2.6.0
+	pytest-cov==2.6.0
 	-r{toxinidir}/requirements_tox_test.txt
 


### PR DESCRIPTION
From what I saw in the codebase, we have only implemented [equal variance t-test](https://en.wikipedia.org/wiki/Student%27s_t-test#Equal_or_unequal_sample_sizes,_equal_variance), not welch's t-test.

We first compute the pooled std [here]( https://github.com/zalando/expan/blob/master/expan/core/statistics.py#L308), and then multiply the pooled std with the square root of ` (1/n1 + 1/n2)` [here](https://github.com/zalando/expan/blob/master/expan/core/statistics.py#L482), which is exactly the formula of equal variance t-test in the link above. As far as I see, I couldn't find implementation of welch's t-test in ExpAn.