### PR TITLE
Remove collaborators approval

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -5,6 +5,5 @@ approvals:
       from:
         orgs:
           - "zalando"
-        collaborators: true
 X-Zalando-Team: "octopus"
 X-Zalando-Type: code


### PR DESCRIPTION
Felix from team Torch advised to remove the collaborators approval, seems it's not working.
Let's try without it.