### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pandas >= 0.18.1
 scipy >= 0.17.0
 numpy >= 1.10.4
 simplejson >= 3.8.2
-pystan >= 2.15
+pystan == 2.19.1.1
 enum34 >= 1.1.6


### PR DESCRIPTION
pystan moved from version 2.* to 3.* 
As such the naming is changed and creates some import errors. Version 2.19.* seems to work fine